### PR TITLE
[feature/user field refactor] : 회원 정보 필드 리팩토링

### DIFF
--- a/CineHive/src/main/java/com/example/CineHive/controller/UserController.java
+++ b/CineHive/src/main/java/com/example/CineHive/controller/UserController.java
@@ -61,17 +61,16 @@ public class UserController {
     @PostMapping("/login")
     public ResponseEntity<Map<String, Object>> login(@RequestBody LoginDto loginRequest) {
         try {
-            boolean loginSuccess = userService.loginUser(loginRequest.getMemUserid(), loginRequest.getMemPassword());
+            boolean loginSuccess = userService.loginUser(loginRequest.getMemEmail(), loginRequest.getMemPassword());
             if (loginSuccess) {
                 // 사용자 정보를 가져와서 응답 생성
-                User user = userService.getUserInfo(loginRequest.getMemUserid());
+                User user = userService.getUserInfo(loginRequest.getMemEmail());
                 Map<String, Object> response = new HashMap<>();
                 response.put("message", "로그인 성공");
                 response.put("user", new HashMap<String, Object>() {{
-                    put("memUserid", user.getMemUserid());
+                    put("email", user.getMemEmail());
                     put("name", user.getMemName());
                     put("nickname", user.getMemNickname());
-                    put("email", user.getMemEmail());
                     put("genres", user.getGenres());
                 }});
 

--- a/CineHive/src/main/java/com/example/CineHive/controller/UserController.java
+++ b/CineHive/src/main/java/com/example/CineHive/controller/UserController.java
@@ -84,15 +84,6 @@ public class UserController {
     }
 
 
-
-    @Operation(summary = "아이디 중복 확인", description = "user 테이블에 해당 아이디가 이미 등록되어 있는지 확인")
-    @GetMapping("/checkuserId/{memUserid}")
-    public ResponseEntity<Boolean> checkUserId(@PathVariable(value="memUserid") String memUserid) {
-        Optional<User> existingUser = userRepository.findByMemUserid(memUserid);
-        boolean isAvailable = existingUser.isEmpty(); // 사용자 ID가 존재하지 않으면 사용 가능
-        return ResponseEntity.ok(isAvailable);
-    }
-
     @Operation(summary = "닉네임 중복 확인", description = "user 테이블에 해당 닉네임이 이미 등록되어 있는지 확인")
     @GetMapping("/checknickname/{memNickname}")
     public ResponseEntity<Boolean> checkmemNickname(@PathVariable(value="memNickname") String memNickname) {

--- a/CineHive/src/main/java/com/example/CineHive/controller/oauthController/GoogleUserController.java
+++ b/CineHive/src/main/java/com/example/CineHive/controller/oauthController/GoogleUserController.java
@@ -115,7 +115,6 @@ public class GoogleUserController {
         newUser.setMemPw(userDto.getMemPassword());
         newUser.setMemNickname(userDto.getMemNickname());
         newUser.setMemName(userDto.getMemName());
-        newUser.setMemPhone(userDto.getMemPhone());
         newUser.setMemSex(userDto.getMemSex());
         newUser.setGoogleId(userDto.getGoogleId());
         newUser.setMemRegisterDatetime(LocalDateTime.now());

--- a/CineHive/src/main/java/com/example/CineHive/controller/oauthController/GoogleUserController.java
+++ b/CineHive/src/main/java/com/example/CineHive/controller/oauthController/GoogleUserController.java
@@ -68,7 +68,7 @@ public class GoogleUserController {
                 System.out.println("GoogleUser found: " + googleUser.getName() + ", " + googleUser.getGenres());
             }
 
-            userInfo.setName(googleUser.getName());
+            userInfo.setMemName(googleUser.getName());
             userInfo.setGenres(googleUser.getGenres());
 
             response.setContentType("application/json");
@@ -124,7 +124,6 @@ public class GoogleUserController {
 
         GoogleUser googleUser = googleUserRepository.findByGoogleId(userDto.getGoogleId())
                 .orElseThrow(() -> new IllegalArgumentException("Google User not found"));
-        googleUser.setMemUserId(userDto.getMemEmail());
         googleUser.setName(userDto.getMemName());  // 이름 업데이트
         googleUser.setGenres(userDto.getGenres());  // 장르 업데이트
         googleUserRepository.save(googleUser);

--- a/CineHive/src/main/java/com/example/CineHive/controller/oauthController/GoogleUserController.java
+++ b/CineHive/src/main/java/com/example/CineHive/controller/oauthController/GoogleUserController.java
@@ -110,7 +110,6 @@ public class GoogleUserController {
     @PostMapping("/google/register")
     public ResponseEntity<String> registerUserDetails(@RequestBody UserDto userDto) {
         User newUser = new User();
-        newUser.setMemUserid(userDto.getMemUserid());
         newUser.setMemEmail(userDto.getMemEmail());
         newUser.setMemPw(userDto.getMemPassword());
         newUser.setMemNickname(userDto.getMemNickname());

--- a/CineHive/src/main/java/com/example/CineHive/controller/oauthController/KakaoUserController.java
+++ b/CineHive/src/main/java/com/example/CineHive/controller/oauthController/KakaoUserController.java
@@ -146,7 +146,6 @@ public class KakaoUserController {
     @PostMapping("/kakao/register")
     public ResponseEntity<String> registerUserDetails(@RequestBody UserDto userDto) {
         User newUser = new User();
-        newUser.setMemUserid(userDto.getMemUserid());
         newUser.setMemEmail(userDto.getMemEmail());
         newUser.setMemPw(userDto.getMemPassword());
         newUser.setMemNickname(userDto.getMemNickname());

--- a/CineHive/src/main/java/com/example/CineHive/controller/oauthController/KakaoUserController.java
+++ b/CineHive/src/main/java/com/example/CineHive/controller/oauthController/KakaoUserController.java
@@ -63,7 +63,7 @@ public class KakaoUserController {
                 System.out.println("GoogleUser found: " + kakaoUser.getName() + ", " + kakaoUser.getGenres());
             }
 
-            userInfo.setName(kakaoUser.getName());
+            userInfo.setMemName(kakaoUser.getName());
             userInfo.setGenres(kakaoUser.getGenres());
 
             response.setContentType("application/json");
@@ -161,7 +161,6 @@ public class KakaoUserController {
 
         KakaoUser kakaoUser = kakaoUserRepository.findByKakaoId(userDto.getKakaoId())
                 .orElseThrow(() -> new IllegalArgumentException("Kakao User not found"));
-        kakaoUser.setMemUserId(userDto.getMemEmail());
         kakaoUser.setName(userDto.getMemName());
         kakaoUser.setGenres(userDto.getGenres());
         kakaoUserRepository.save(kakaoUser);

--- a/CineHive/src/main/java/com/example/CineHive/controller/oauthController/KakaoUserController.java
+++ b/CineHive/src/main/java/com/example/CineHive/controller/oauthController/KakaoUserController.java
@@ -151,7 +151,6 @@ public class KakaoUserController {
         newUser.setMemPw(userDto.getMemPassword());
         newUser.setMemNickname(userDto.getMemNickname());
         newUser.setMemName(userDto.getMemName());
-        newUser.setMemPhone(userDto.getMemPhone());
         newUser.setMemSex(userDto.getMemSex());
         newUser.setKakaoId(userDto.getKakaoId());
         newUser.setMemRegisterDatetime(LocalDateTime.now());

--- a/CineHive/src/main/java/com/example/CineHive/controller/oauthController/NaverUserController.java
+++ b/CineHive/src/main/java/com/example/CineHive/controller/oauthController/NaverUserController.java
@@ -109,7 +109,6 @@ public class NaverUserController {
     @PostMapping("/naver/register")
     public ResponseEntity<String> registerUserDetails(@RequestBody UserDto userDto) {
         User newUser = new User();
-        newUser.setMemUserid(userDto.getMemUserid());
         newUser.setMemEmail(userDto.getMemEmail());
         newUser.setMemPw(userDto.getMemPassword());
         newUser.setMemNickname(userDto.getMemNickname());

--- a/CineHive/src/main/java/com/example/CineHive/controller/oauthController/NaverUserController.java
+++ b/CineHive/src/main/java/com/example/CineHive/controller/oauthController/NaverUserController.java
@@ -46,7 +46,7 @@ public class NaverUserController {
         String redirectUrl = "https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=" + naverUserService.getClientId() +
                 "&redirect_uri=" + URLEncoder.encode("http://localhost:8081/api/auth/naver/callback", "UTF-8") +
                 "&state=" + UUID.randomUUID().toString() +
-                "&scope=name,email,gender,nickname,phone"; // 필요한 스코프 추가
+                "&scope=name,email,nickname"; // 필요한 스코프 추가
         response.sendRedirect(redirectUrl);
     }
 

--- a/CineHive/src/main/java/com/example/CineHive/controller/oauthController/NaverUserController.java
+++ b/CineHive/src/main/java/com/example/CineHive/controller/oauthController/NaverUserController.java
@@ -67,7 +67,7 @@ public class NaverUserController {
                 System.out.println("GoogleUser found: " + naverUser.getName() + ", " + naverUser.getGenres());
             }
 
-            userInfo.setName(naverUser.getName());
+            userInfo.setMemName(naverUser.getName());
             userInfo.setGenres(naverUser.getGenres());
 
             response.setContentType("application/json");
@@ -125,7 +125,6 @@ public class NaverUserController {
 
         NaverUser naverUser = naverUserRepository.findByNaverId(userDto.getNaverId())
                 .orElseThrow(() -> new IllegalArgumentException("Kakao User not found"));
-        naverUser.setMemUserId(userDto.getMemEmail());
         naverUser.setName(userDto.getMemName());
         naverUser.setGenres(userDto.getGenres());
         naverUserRepository.save(naverUser);

--- a/CineHive/src/main/java/com/example/CineHive/controller/oauthController/NaverUserController.java
+++ b/CineHive/src/main/java/com/example/CineHive/controller/oauthController/NaverUserController.java
@@ -114,7 +114,6 @@ public class NaverUserController {
         newUser.setMemPw(userDto.getMemPassword());
         newUser.setMemNickname(userDto.getMemNickname());
         newUser.setMemName(userDto.getMemName());
-        newUser.setMemPhone(userDto.getMemPhone());
         newUser.setMemSex(userDto.getMemSex());
         newUser.setNaverId(userDto.getNaverId()); // 카카오 ID 추가
         newUser.setMemRegisterDatetime(LocalDateTime.now());

--- a/CineHive/src/main/java/com/example/CineHive/dto/oauth/GoogleUserInfo.java
+++ b/CineHive/src/main/java/com/example/CineHive/dto/oauth/GoogleUserInfo.java
@@ -13,8 +13,8 @@ import java.util.List;
 @AllArgsConstructor
 public class GoogleUserInfo {
     private String googleId;
-    private String email;
-    private String nickname;
-    private String name;
+    private String memEmail;
+    private String memNickname;
+    private String memName;
     private List<String> genres;
 }

--- a/CineHive/src/main/java/com/example/CineHive/dto/oauth/KakaoUserInfo.java
+++ b/CineHive/src/main/java/com/example/CineHive/dto/oauth/KakaoUserInfo.java
@@ -15,8 +15,8 @@ import java.util.List;
 public class KakaoUserInfo {
 
     private String kakaoId;
-    private String email;
-    private String nickname;
-    private String name;
+    private String memEmail;
+    private String memNickname;
+    private String memName;
     private List<String> genres;
 }

--- a/CineHive/src/main/java/com/example/CineHive/dto/oauth/NaverUserInfo.java
+++ b/CineHive/src/main/java/com/example/CineHive/dto/oauth/NaverUserInfo.java
@@ -15,8 +15,8 @@ import java.util.List;
 public class NaverUserInfo {
 
     private String naverId;
-    private String email;
-    private String nickname;
-    private String name;
+    private String memEmail;
+    private String memNickname;
+    private String memName;
     private List<String> genres;
 }

--- a/CineHive/src/main/java/com/example/CineHive/dto/user/LoginDto.java
+++ b/CineHive/src/main/java/com/example/CineHive/dto/user/LoginDto.java
@@ -6,15 +6,15 @@ import lombok.Setter;
 @Getter
 @Setter
 public class LoginDto {
-    private String memUserid;
+    private String memEmail;
     private String memPassword;
 
     // 기본 생성자
     public LoginDto() {}
 
     // 생성자
-    public LoginDto(String memUserid, String memPassword) {
-        this.memUserid = memUserid;
+    public LoginDto(String memEmail, String memPassword) {
+        this.memEmail = memEmail;
         this.memPassword = memPassword;
     }
 }

--- a/CineHive/src/main/java/com/example/CineHive/dto/user/UserDto.java
+++ b/CineHive/src/main/java/com/example/CineHive/dto/user/UserDto.java
@@ -14,7 +14,6 @@ import java.util.List;
 public class UserDto {
     private boolean exists; // 사용자 존재 여부
     private Long mem_id;
-    private String memUserid;
     private String memPassword;
     private String memName;
     private String memEmail;

--- a/CineHive/src/main/java/com/example/CineHive/dto/user/UserDto.java
+++ b/CineHive/src/main/java/com/example/CineHive/dto/user/UserDto.java
@@ -18,7 +18,6 @@ public class UserDto {
     private String memPassword;
     private String memName;
     private String memEmail;
-    private String memPhone;
     private String memNickname;
     private String memSex;
     private String memType;

--- a/CineHive/src/main/java/com/example/CineHive/entity/User.java
+++ b/CineHive/src/main/java/com/example/CineHive/entity/User.java
@@ -39,9 +39,6 @@ public class User {
     @Column
     private String memSex;
 
-    @Column
-    private String memPhone;
-
     @Column(nullable = false)
     private LocalDateTime memRegisterDatetime;
 

--- a/CineHive/src/main/java/com/example/CineHive/entity/User.java
+++ b/CineHive/src/main/java/com/example/CineHive/entity/User.java
@@ -30,13 +30,13 @@ public class User {
     @Column(nullable = false, unique = true)
     private String memEmail;
 
-    @Column
+    @Column(nullable = true)
     private String memName;
 
     @Column(nullable = false)
     private String memNickname;
 
-    @Column
+    @Column(nullable = true)
     private String memSex;
 
     @Column(nullable = false)

--- a/CineHive/src/main/java/com/example/CineHive/entity/User.java
+++ b/CineHive/src/main/java/com/example/CineHive/entity/User.java
@@ -21,9 +21,6 @@ public class User {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long mem_id;
 
-    @Column(nullable = true)
-    private String memUserid;
-
     @Column
     private String memPw;
 

--- a/CineHive/src/main/java/com/example/CineHive/entity/oauth/GoogleUser.java
+++ b/CineHive/src/main/java/com/example/CineHive/entity/oauth/GoogleUser.java
@@ -27,8 +27,8 @@ public class GoogleUser {
     @Column(length = 50)
     private String nickname;
 
-    @Column(name = "mem_userid", nullable = true)
-    private String memUserId;
+    @Column(name = "mem_email", nullable = true)
+    private String memEmail;
 
     @Column(name = "user_id")
     private Long userId; // users 테이블의 외래 키
@@ -47,10 +47,10 @@ public class GoogleUser {
     private List<String> genres;
 
 
-    public GoogleUser(String googleId, String nickname, String memUserId, String name, List<String> genres) {
+    public GoogleUser(String googleId, String nickname, String memEmail, String name, List<String> genres) {
         this.googleId = googleId;
         this.nickname = nickname;
-        this.memUserId = memUserId;
+        this.memEmail = memEmail;
         this.name = name;
         this.genres = genres;
     }

--- a/CineHive/src/main/java/com/example/CineHive/entity/oauth/KakaoUser.java
+++ b/CineHive/src/main/java/com/example/CineHive/entity/oauth/KakaoUser.java
@@ -28,8 +28,8 @@ public class KakaoUser {
     @Column(length = 50)
     private String nickname;
 
-    @Column(name = "mem_userid", nullable = true)
-    private String memUserId;
+    @Column(name = "mem_email", nullable = true)
+    private String memEmail;
 
     @Column(name = "user_id")
     private Long userId; // users 테이블의 외래 키
@@ -47,10 +47,10 @@ public class KakaoUser {
     @Column(name = "genre")
     private List<String> genres;
 
-    public KakaoUser(String kakaoId, String nickname, String memUserId,String name, List<String> genres) {
+    public KakaoUser(String kakaoId, String nickname, String memEmail,String name, List<String> genres) {
         this.kakaoId = kakaoId;
         this.nickname = nickname;
-        this.memUserId = memUserId;
+        this.memEmail = memEmail;
         this.name = name;
         this.genres = genres;
     }

--- a/CineHive/src/main/java/com/example/CineHive/entity/oauth/NaverUser.java
+++ b/CineHive/src/main/java/com/example/CineHive/entity/oauth/NaverUser.java
@@ -27,8 +27,8 @@ public class NaverUser {
     @Column(length = 50)
     private String nickname;
 
-    @Column(name = "mem_userid", nullable = true)
-    private String memUserId; //이메일
+    @Column(name = "mem_email", nullable = true)
+    private String memEmail; //이메일
 
     @Column(name = "user_id")
     private Long userId;
@@ -46,10 +46,10 @@ public class NaverUser {
     @Column(name = "genre")
     private List<String> genres;
 
-    public NaverUser(String naverId, String nickname, String memUserId, String name, List<String> genres) {
+    public NaverUser(String naverId, String nickname, String memEmail, String name, List<String> genres) {
         this.naverId = naverId;
         this.nickname = nickname;
-        this.memUserId = memUserId;
+        this.memEmail = memEmail;
         this.name = name;
         this.genres = genres;
     }

--- a/CineHive/src/main/java/com/example/CineHive/mapper/UserMapper.java
+++ b/CineHive/src/main/java/com/example/CineHive/mapper/UserMapper.java
@@ -9,7 +9,6 @@ public class UserMapper {
     public User toEntity(UserDto userDto) {
         User user = new User();
         user.setMemEmail(userDto.getMemEmail());
-        user.setMemUserid(userDto.getMemUserid());
         user.setMemPw(userDto.getMemPassword());
         user.setMemName(userDto.getMemName());
         user.setMemSex(userDto.getMemSex());

--- a/CineHive/src/main/java/com/example/CineHive/mapper/UserMapper.java
+++ b/CineHive/src/main/java/com/example/CineHive/mapper/UserMapper.java
@@ -13,7 +13,6 @@ public class UserMapper {
         user.setMemPw(userDto.getMemPassword());
         user.setMemName(userDto.getMemName());
         user.setMemSex(userDto.getMemSex());
-        user.setMemPhone(userDto.getMemPhone());
         user.setMemNickname(userDto.getMemNickname());
         user.setMemRegisterDatetime(LocalDateTime.now());
         user.setGenres(userDto.getGenres());

--- a/CineHive/src/main/java/com/example/CineHive/repository/UserRepository.java
+++ b/CineHive/src/main/java/com/example/CineHive/repository/UserRepository.java
@@ -12,7 +12,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByKakaoId(String kakaoId);
     Optional<User> findByNaverId(String naverId);
     Optional<User> findByGoogleId(String googleId);
-    Optional<User> findByMemUserid(String memUserid);
 
     Optional<User> findByMemEmail(String memEmail);
 

--- a/CineHive/src/main/java/com/example/CineHive/service/UserService.java
+++ b/CineHive/src/main/java/com/example/CineHive/service/UserService.java
@@ -33,12 +33,7 @@ public class UserService{
     }
 
 
-    public void checkDuplicateUserId(String memUserid) {
-        Optional<User> existingUser = userRepository.findByMemUserid(memUserid);
-        if (existingUser.isPresent()) {
-            throw new IllegalArgumentException("이미 존재하는 사용자 ID입니다.");
-        }
-    }
+
 
     public void checkDuplicateEmail(String memEmail) {
         Optional<User> existingUser = userRepository.findByMemEmail(memEmail);

--- a/CineHive/src/main/java/com/example/CineHive/service/UserService.java
+++ b/CineHive/src/main/java/com/example/CineHive/service/UserService.java
@@ -54,9 +54,9 @@ public class UserService{
         }
     }
 
-    public boolean loginUser(String memUserid, String memPassword) {
+    public boolean loginUser(String memEmail, String memPassword) {
         // 사용자 ID로 사용자 조회
-        Optional<User> existingUser = userRepository.findByMemUserid(memUserid);
+        Optional<User> existingUser = userRepository.findByMemEmail(memEmail);
 
         if (existingUser.isEmpty()) {
             throw new IllegalArgumentException("존재하지 않는 사용자입니다.");
@@ -83,8 +83,8 @@ public class UserService{
     }
 
 
-    public User getUserInfo(String memUserid) {
-        return userRepository.findByMemUserid(memUserid).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+    public User getUserInfo(String memEmail) {
+        return userRepository.findByMemEmail(memEmail).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
     }
 
 }

--- a/CineHive/src/main/java/com/example/CineHive/service/oauth/GoogleUserService.java
+++ b/CineHive/src/main/java/com/example/CineHive/service/oauth/GoogleUserService.java
@@ -78,8 +78,8 @@ public class GoogleUserService {
             JSONObject jsonObject = new JSONObject(response.getBody());
             GoogleUserInfo userInfo = new GoogleUserInfo();
             userInfo.setGoogleId(jsonObject.getString("id"));
-            userInfo.setNickname(jsonObject.getString("name"));
-            userInfo.setEmail(jsonObject.getString("email"));
+            userInfo.setMemNickname(jsonObject.getString("name"));
+            userInfo.setMemEmail(jsonObject.getString("email"));
             return userInfo;
         } else {
             throw new IOException("Failed to get user info: " + response.getStatusCode());
@@ -88,7 +88,7 @@ public class GoogleUserService {
 
     public void registerUser(GoogleUserInfo userInfo) {
         GoogleUser googleUser = googleUserRepository.findByGoogleId(userInfo.getGoogleId())
-                .orElse(new GoogleUser(userInfo.getGoogleId(), userInfo.getNickname(), userInfo.getEmail(), null, null));
+                .orElse(new GoogleUser(userInfo.getGoogleId(), userInfo.getMemNickname(), userInfo.getMemEmail(), null, null));
 
         googleUserRepository.save(googleUser);
     }
@@ -100,9 +100,9 @@ public class GoogleUserService {
         // 이제 GoogleUser 엔티티를 생성하고 memUserId를 설정
         GoogleUser googleUser = new GoogleUser();
         googleUser.setGoogleId(userInfo.getGoogleId());
-        googleUser.setNickname(userInfo.getNickname());
-        googleUser.setMemUserId(user.getMemUserid());
-        googleUser.setName(userInfo.getName());
+        googleUser.setNickname(userInfo.getMemNickname());
+        googleUser.setMemEmail(userInfo.getMemEmail());
+        googleUser.setName(userInfo.getMemName());
         googleUser.setGenres(userInfo.getGenres());
         googleUserRepository.save(googleUser);
 

--- a/CineHive/src/main/java/com/example/CineHive/service/oauth/GoogleUserService.java
+++ b/CineHive/src/main/java/com/example/CineHive/service/oauth/GoogleUserService.java
@@ -97,7 +97,7 @@ public class GoogleUserService {
         // 먼저 User 엔티티에 사용자 정보 저장
         User user = new User();
 
-        // 이제 GoogleUser 엔티티를 생성하고 memUserId를 설정
+
         GoogleUser googleUser = new GoogleUser();
         googleUser.setGoogleId(userInfo.getGoogleId());
         googleUser.setNickname(userInfo.getMemNickname());

--- a/CineHive/src/main/java/com/example/CineHive/service/oauth/KakaoUserService.java
+++ b/CineHive/src/main/java/com/example/CineHive/service/oauth/KakaoUserService.java
@@ -81,18 +81,18 @@ public class KakaoUserService {
                 userInfo.setKakaoId(userInfo.getKakaoId());
                 userInfo.setKakaoId(String.valueOf(jsonObject.getLong("id")));
                 JSONObject properties = jsonObject.getJSONObject("properties");
-                userInfo.setNickname(properties.getString("nickname"));
+                userInfo.setMemNickname(properties.getString("nickname"));
 
                 // 이메일 필드가 있는지 확인
                 if (jsonObject.has("kakao_account")) {
                     JSONObject kakaoAccount = jsonObject.getJSONObject("kakao_account");
                     if (kakaoAccount.has("email")) {
-                        userInfo.setEmail(kakaoAccount.getString("email"));
+                        userInfo.setMemEmail(kakaoAccount.getString("email"));
                     } else {
-                        userInfo.setEmail("이메일 미제공"); // 기본값 설정
+                        userInfo.setMemEmail("이메일 미제공"); // 기본값 설정
                     }
                 } else {
-                    userInfo.setEmail("이메일 미제공");
+                    userInfo.setMemEmail("이메일 미제공");
                 }
                 return userInfo;
             } else {
@@ -104,7 +104,7 @@ public class KakaoUserService {
 
     public void registerUser(KakaoUserInfo userInfo) {
         KakaoUser socialUser = kakaouserRepository.findByKakaoId(userInfo.getKakaoId())
-                .orElse(new KakaoUser(userInfo.getKakaoId(), userInfo.getNickname(), userInfo.getEmail(), null, null));
+                .orElse(new KakaoUser(userInfo.getKakaoId(), userInfo.getMemNickname(), userInfo.getMemEmail(), null, null));
         kakaouserRepository.save(socialUser);
         }
 
@@ -114,9 +114,9 @@ public class KakaoUserService {
 
         KakaoUser kakaoUser = new KakaoUser();
         kakaoUser.setKakaoId(userInfo.getKakaoId());
-        kakaoUser.setNickname(userInfo.getNickname());
-        kakaoUser.setMemUserId(user.getMemUserid());
-        kakaoUser.setName(userInfo.getName());
+        kakaoUser.setNickname(userInfo.getMemNickname());
+        kakaoUser.setMemEmail(userInfo.getMemEmail());
+        kakaoUser.setName(userInfo.getMemName());
         kakaoUser.setGenres(userInfo.getGenres());
         kakaouserRepository.save(kakaoUser);
 

--- a/CineHive/src/main/java/com/example/CineHive/service/oauth/NaverUserService.java
+++ b/CineHive/src/main/java/com/example/CineHive/service/oauth/NaverUserService.java
@@ -84,8 +84,8 @@ public class NaverUserService {
 
             NaverUserInfo userInfo = new NaverUserInfo();
             userInfo.setNaverId(responseObject.getString("id"));
-            userInfo.setEmail(responseObject.getString("email"));
-            userInfo.setNickname(responseObject.getString("nickname"));
+            userInfo.setMemEmail(responseObject.getString("email"));
+            userInfo.setMemNickname(responseObject.getString("nickname"));
 
             return userInfo;
         } else {
@@ -95,7 +95,7 @@ public class NaverUserService {
 
     public void registerUser(NaverUserInfo userInfo) {
         NaverUser naverUser = naverUserRepository.findByNaverId(userInfo.getNaverId())
-                .orElse(new NaverUser(userInfo.getNaverId(), userInfo.getNickname(), userInfo.getEmail(), null, null));
+                .orElse(new NaverUser(userInfo.getNaverId(), userInfo.getMemNickname(), userInfo.getMemEmail(), null, null));
 
         naverUserRepository.save(naverUser);
     }
@@ -107,8 +107,9 @@ public class NaverUserService {
 
         NaverUser naverUser = new NaverUser();
         naverUser.setNaverId(userInfo.getNaverId());
-        naverUser.setNickname(userInfo.getNickname());
-        naverUser.setName(userInfo.getName());
+        naverUser.setNickname(userInfo.getMemNickname());
+        naverUser.setMemEmail(userInfo.getMemEmail());
+        naverUser.setName(userInfo.getMemName());
         naverUser.setGenres(userInfo.getGenres());
         naverUserRepository.save(naverUser);  // GoogleUser 테이블에 저장
 


### PR DESCRIPTION
## 작업 내용
- User 테이블에서 memUserId, memPhone 필드 제거
- 소셜(Kakao, Naver, Google) 테이블 memUserId -> memEmail 필드로 변경
- KakaoUserInfo, NaverUserInfo, GoogleUserInfo의 필드명을 일관성 있게 통일
- User 테이블 memName, memSex 필드 -> nullable=true로 명시적으로 null 값 허용하도록 변경 
- naver Open API에서 제공하는 동의 항목에 대해 기존 scope 값에서 phone,gender를 제외하여 받아오도록 수정

## PR Point
- postman 및 Talend API Tester를 통해 정상 작동 및 예외 처리가 되는지 확인하였음
- 영화 상세 페이지 기능 ->  찜하기, 감상 평 작성, 리뷰 작성 기능에 대해  memEmail 값으로 불러오도록 해야 함
## 스크린샷
X