### PR TITLE
[Fix]: 게시판 좋아요 갯수 조회 시 BookmarkCount에서 LikeCount로 수정

### DIFF
--- a/CineHive/src/main/java/com/example/CineHive/service/board/LikeService.java
+++ b/CineHive/src/main/java/com/example/CineHive/service/board/LikeService.java
@@ -72,7 +72,7 @@ public class LikeService {
     public int getLikeCount(Long boardId) {
         Board board = boardRepository.findById(boardId)
                 .orElseThrow(() -> new RuntimeException("Board not found"));
-        return board.getBookmarkCount();
+        return board.getLikeCount();
     }
 
 }


### PR DESCRIPTION
## 작업 내용
- 좋아요 갯수 조회 시 bookmarkCount 객체로 반영되고 있던 코드 수정

## PR Point
- 좋아요를 클릭했을 때 좋아요 수가 증가 해야 하는데, 즐겨찾기 수가 증가하고 있고 있는 부분에서 return 값을 bookmarkCount에서 `likeCount`로 수정

## 스크린샷
X