### PR TITLE
[feature/user-login-fix]: 로그인 시 성별 정보를 포함하도록 수정

### DIFF
--- a/CineHive/src/main/java/com/example/CineHive/controller/UserController.java
+++ b/CineHive/src/main/java/com/example/CineHive/controller/UserController.java
@@ -82,6 +82,7 @@ public class UserController {
                 Map<String, Object> response = new HashMap<>();
                 response.put("message", "로그인 성공");
                 response.put("user", new HashMap<String, Object>() {{
+                    put("gender",user.getMemSex());
                     put("email", user.getMemEmail());
                     put("name", user.getMemName());
                     put("nickname", user.getMemNickname());


### PR DESCRIPTION
## 작업 내용
- 로그인 시 성별 정보를 포함하도록 수정

## PR Point
-  기존 코드는 성별 정보는 포함하지 않고 로그인이 되도록 하였음.  
    회원가입 시 `성별`과 `이름`은 필수 입력 필드가 아니여서 기입하지 않아도 회원 가입이 됨
    그러나 마이페이지에서 정보 조회를 위해 회원가입 시 존재하는 모든 필드를 포함하여 로그인이 가능하도록 수정하였음.

- 스크린샷에 대해 example의  json 데이터는 추가적인 속성을 나타내는 구조. 이는, 특정 API의 요청 본문에서 동적으로 추가할 수 있는 속성을 의미 즉, additionalProp1, additionalProp2, additionalProp3는 특정 필드가 아닌, 사용자가 필요에 따라 추가할 수 있는 자리 표시자 -> `kakao`, `naver`, `google` 를 의미

## 스크린샷
![image](https://github.com/user-attachments/assets/43ea92eb-a346-461b-b8b4-2756485739ea)
