### PR TITLE
[feature/movie-detail-fix] : 영화 및 애니메이션 상세 정보 조회 시 관련된 정보를 제공하도록 데이터 추가

### DIFF
--- a/CineHive/src/main/java/com/example/CineHive/config/SecurityConfig.java
+++ b/CineHive/src/main/java/com/example/CineHive/config/SecurityConfig.java
@@ -45,7 +45,7 @@ public class SecurityConfig {
                                 "/report/{boardId}/users/{memEmail}",
                                 "/comment/{boardId}/{memEmail}","/comment/all/board/{boardId}","/comment/board/{boardId}/delete/{commentId}","/comment/board/{boardId}/update/{commentId}"
                         ,"/boards/search","/update_now_playing","/update_top_movie","/get_upcoming_movies","/update_upcoming_movie",
-                                "/update_popular_movie","/get_popular_movies").permitAll()
+                                "/update_popular_movie","/get_popular_movies","/movies/{id}/similar").permitAll()
                         .requestMatchers("/login", "/register", "/checkuserId/**","/checknickname/**","/checkemail/**",
                                 "/api/auth/kakao/check-user","/api/auth/kakao/register",
                                 "/api/auth/google/register","/api/auth/google/check-user","/api/auth/naver/check-user","/api/auth/naver/register").permitAll() // 로그인과 회원가입은 누구나 접근 가능

--- a/CineHive/src/main/java/com/example/CineHive/controller/AnimationController.java
+++ b/CineHive/src/main/java/com/example/CineHive/controller/AnimationController.java
@@ -2,6 +2,7 @@ package com.example.CineHive.controller;
 
 import com.example.CineHive.entity.videotype.Animation;
 import com.example.CineHive.repository.videos.animation.AnimationRepository;
+import com.example.CineHive.service.credit.animation.SimilarAnimationService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,6 +21,8 @@ public class  AnimationController {
 
     @Autowired
     private AnimationRepository animationRepository;
+    @Autowired
+    private SimilarAnimationService similarAnimationService;
     @Operation(summary = "Animation 상세 페이지 받아오기", description = "해당 Animation ID로 Animation 정보를 상세 페이지에 반환, 존재하지 않는 경우 404 응답을 반환")
     @GetMapping("/animations/{id}")
     @ResponseBody
@@ -38,4 +41,13 @@ public class  AnimationController {
     public List<Animation> getMovies(){
         return animationRepository.findAll();
     }
+
+    @Operation(summary = "관련 추천 애니메이션 조회", description = "특정 애니메이션 ID로 TMDB의 추천 애니메이션 목록을 가져옴")
+    @GetMapping("/animations/{id}/similar")
+    @ResponseBody
+    public ResponseEntity<List<Animation>> getSimilarAnimations(@PathVariable Long id) {
+        List<Animation> similarAnimations = similarAnimationService.getSimilarAnimations(id);
+        return ResponseEntity.ok(similarAnimations);
+    }
+
 }

--- a/CineHive/src/main/java/com/example/CineHive/controller/movie/MovieController.java
+++ b/CineHive/src/main/java/com/example/CineHive/controller/movie/MovieController.java
@@ -10,6 +10,7 @@ import com.example.CineHive.service.credit.animation.AnimationService;
 import com.example.CineHive.service.credit.drama.DramaService;
 import com.example.CineHive.service.credit.movie.MovieService;
 import com.example.CineHive.service.credit.movie.NowPlayingMovieService;
+import com.example.CineHive.service.credit.movie.SimilarMovieService;
 import com.example.CineHive.service.credit.movie.TopRatedMovieService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -32,6 +33,9 @@ public class MovieController {
     @Autowired
     private MovieRepository movieRepository;
 
+    @Autowired
+    private SimilarMovieService similarMovieService;
+
     @Operation(summary = "DB에서 영화 받아오기", description = "movie 테이블에 저장된 모든 movie 정보를 리스트 형태로 반환")
     @GetMapping("/movies")
     @ResponseBody
@@ -51,4 +55,11 @@ public class MovieController {
         }
     }
 
+    @Operation(summary = "관련 추천 영화 조회", description = "특정 영화 ID로 TMDB의 추천 영화 목록을 가져옴")
+    @GetMapping("/movies/{id}/similar")
+    @ResponseBody
+    public ResponseEntity<List<Movie>> getSimilarMovies(@PathVariable Long id) {
+        List<Movie> similarMovies = similarMovieService.getSimilarMovies(id);
+        return ResponseEntity.ok(similarMovies);
+    }
 }

--- a/CineHive/src/main/java/com/example/CineHive/entity/videotype/Animation.java
+++ b/CineHive/src/main/java/com/example/CineHive/entity/videotype/Animation.java
@@ -35,7 +35,7 @@ public class Animation {
     private LocalDate releaseDate;
     private double voteAverage;
     private double popularity;
-
+    private int runtime;
     @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     @JoinColumn(name = "animation_id")
     private List<Genre> genres = new ArrayList<>();
@@ -47,4 +47,6 @@ public class Animation {
     @OneToMany(mappedBy = "animation", cascade = CascadeType.ALL, orphanRemoval = true)
     @JsonManagedReference
     private List<Video> videos = new ArrayList<>();
+
+
 }

--- a/CineHive/src/main/java/com/example/CineHive/entity/videotype/Animation.java
+++ b/CineHive/src/main/java/com/example/CineHive/entity/videotype/Animation.java
@@ -48,5 +48,9 @@ public class Animation {
     @JsonManagedReference
     private List<Video> videos = new ArrayList<>();
 
+    @ElementCollection
+    @CollectionTable(name = "recommended_animations", joinColumns = @JoinColumn(name = "animation_id"))
+    @Column(name = "recommended_animation_id")
+    private List<Long> recommendedAnimationIds = new ArrayList<>();
 
 }

--- a/CineHive/src/main/java/com/example/CineHive/entity/videotype/Movie.java
+++ b/CineHive/src/main/java/com/example/CineHive/entity/videotype/Movie.java
@@ -60,4 +60,10 @@ public class Movie {
     private Director director;
 
     private int runtime;
+
+    @ElementCollection
+    @CollectionTable(name = "recommended_movies", joinColumns = @JoinColumn(name = "movie_id"))
+    @Column(name = "recommended_movie_id")
+    private List<Long> recommendedMovieIds;
+
 }

--- a/CineHive/src/main/java/com/example/CineHive/entity/videotype/Movie.java
+++ b/CineHive/src/main/java/com/example/CineHive/entity/videotype/Movie.java
@@ -61,9 +61,7 @@ public class Movie {
 
     private int runtime;
 
-    @ElementCollection
-    @CollectionTable(name = "recommended_movies", joinColumns = @JoinColumn(name = "movie_id"))
-    @Column(name = "recommended_movie_id")
-    private List<Long> recommendedMovieIds;
+    @OneToMany(mappedBy = "movie", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<RecommendationMovie> recommendedMovies;
 
 }

--- a/CineHive/src/main/java/com/example/CineHive/entity/videotype/Movie.java
+++ b/CineHive/src/main/java/com/example/CineHive/entity/videotype/Movie.java
@@ -61,7 +61,9 @@ public class Movie {
 
     private int runtime;
 
-    @OneToMany(mappedBy = "movie", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<RecommendationMovie> recommendedMovies;
+    @ElementCollection
+    @CollectionTable(name = "recommended_movies", joinColumns = @JoinColumn(name = "movie_id"))
+    @Column(name = "recommended_movie_id")
+    private List<Long> recommendedMovieIds;
 
 }

--- a/CineHive/src/main/java/com/example/CineHive/entity/videotype/RecommendationAnimation.java
+++ b/CineHive/src/main/java/com/example/CineHive/entity/videotype/RecommendationAnimation.java
@@ -1,0 +1,26 @@
+package com.example.CineHive.entity.videotype;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class RecommendationAnimation {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "animation_id")
+    private Animation animation;
+
+    @ManyToOne
+    @JoinColumn(name = "recommended_animation_id")
+    private Animation recommendedAnimation;
+}

--- a/CineHive/src/main/java/com/example/CineHive/entity/videotype/RecommendationMovie.java
+++ b/CineHive/src/main/java/com/example/CineHive/entity/videotype/RecommendationMovie.java
@@ -1,0 +1,27 @@
+package com.example.CineHive.entity.videotype;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class RecommendationMovie {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "movie_id")
+    private Movie movie;
+
+    @ManyToOne
+    @JoinColumn(name = "recommended_movie_id")
+    private Movie recommendedMovie;
+}

--- a/CineHive/src/main/java/com/example/CineHive/repository/videos/animation/AnimationDirectorRepository.java
+++ b/CineHive/src/main/java/com/example/CineHive/repository/videos/animation/AnimationDirectorRepository.java
@@ -1,0 +1,8 @@
+package com.example.CineHive.repository.videos.animation;
+
+import com.example.CineHive.entity.credit.animation.Director;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AnimationDirectorRepository extends JpaRepository<Director,Long> {
+    Director findByName(String name);
+}

--- a/CineHive/src/main/java/com/example/CineHive/repository/videos/animation/AnimationRecommendationRepository.java
+++ b/CineHive/src/main/java/com/example/CineHive/repository/videos/animation/AnimationRecommendationRepository.java
@@ -1,0 +1,7 @@
+package com.example.CineHive.repository.videos.animation;
+
+import com.example.CineHive.entity.videotype.RecommendationAnimation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AnimationRecommendationRepository extends JpaRepository<RecommendationAnimation, Long> {
+}

--- a/CineHive/src/main/java/com/example/CineHive/repository/videos/movie/MovieRecommendationRepository.java
+++ b/CineHive/src/main/java/com/example/CineHive/repository/videos/movie/MovieRecommendationRepository.java
@@ -1,0 +1,13 @@
+package com.example.CineHive.repository.videos.movie;
+
+import com.example.CineHive.entity.videotype.Movie;
+import com.example.CineHive.entity.videotype.RecommendationMovie;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface MovieRecommendationRepository extends JpaRepository<RecommendationMovie, Long> {
+    List<RecommendationMovie> findByMovie(Movie movie);
+}

--- a/CineHive/src/main/java/com/example/CineHive/service/credit/animation/AnimationDirectorService.java
+++ b/CineHive/src/main/java/com/example/CineHive/service/credit/animation/AnimationDirectorService.java
@@ -3,6 +3,7 @@ package com.example.CineHive.service.credit.animation;
 import com.example.CineHive.dto.video.animation.DirectorDto; // DTO 임포트
 import com.example.CineHive.entity.credit.animation.Director; // 애니메이션 감독 엔티티
 import com.example.CineHive.entity.videotype.Animation; // 애니메이션 엔티티
+import com.example.CineHive.repository.videos.animation.AnimationDirectorRepository;
 import com.example.CineHive.repository.videos.animation.AnimationRepository; // 애니메이션 리포지토리
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -29,6 +30,9 @@ public class AnimationDirectorService {
     @Autowired
     private ObjectMapper objectMapper;
 
+    @Autowired
+    private AnimationDirectorRepository animationDirectorRepository;
+
     public AnimationDirectorService(WebClient.Builder webClientBuilder) {
         this.webClient = webClientBuilder.baseUrl("https://api.themoviedb.org/3").build();
     }
@@ -53,19 +57,30 @@ public class AnimationDirectorService {
                     for (JsonNode crewMember : crewNode) {
                         // 감독 정보를 찾기 위해 "job" 속성이 "Director"인 경우만 필터링
                         if ("Director".equals(crewMember.get("job").asText())) {
-                            Director director = new Director();
-                            director.setName(crewMember.get("name").asText());
-                            director.setAnimation(animation);
+                            String directorName = crewMember.get("name").asText();
 
-                            animation.getDirectors().add(director);
+                            // 감독이 이미 존재하는지 확인
+                            Director existingDirector = animationDirectorRepository.findByName(directorName);
+                            if (existingDirector == null) {
+                                Director director = new Director();
+                                director.setName(directorName);
+                                director.setAnimation(animation);
+                                animation.getDirectors().add(director);
+                                animationDirectorRepository.save(director);
 
+                                DirectorDto directorDto = new DirectorDto();
+                                directorDto.setId(director.getId());
+                                directorDto.setName(director.getName());
+                                directorDTOs.add(directorDto);
+                            } else {
+                                // 기존 감독 추가
+                                animation.getDirectors().add(existingDirector);
 
-                            DirectorDto directorDto = new DirectorDto();
-                            directorDto.setId(director.getId());
-                            directorDto.setName(director.getName());
-                            directorDTOs.add(directorDto);
-
-                            break;
+                                DirectorDto directorDto = new DirectorDto();
+                                directorDto.setId(existingDirector.getId());
+                                directorDto.setName(existingDirector.getName());
+                                directorDTOs.add(directorDto);
+                            }
                         }
                     }
                     animationRepository.save(animation);

--- a/CineHive/src/main/java/com/example/CineHive/service/credit/animation/AnimationService.java
+++ b/CineHive/src/main/java/com/example/CineHive/service/credit/animation/AnimationService.java
@@ -40,6 +40,9 @@ public class AnimationService {
     @Autowired
     private AnimationGenreService animationGenreService;
 
+    @Autowired
+    private SimilarAnimationService similarAnimationService;
+
     public AnimationService(WebClient.Builder webClientBuilder, ObjectMapper objectMapper) {
         this.webClient = webClientBuilder.baseUrl("https://api.themoviedb.org/3").build();
         this.objectMapper = objectMapper;
@@ -115,7 +118,6 @@ public class AnimationService {
                     }
                     animation.setGenres(genres);
 
-
                     // 비디오 정보를 가져옴
                     VideoDto videoDto = animationVideoService.getFirstVideoForAnimation(animationId);
                     if (videoDto != null) {
@@ -130,8 +132,19 @@ public class AnimationService {
                     animationRepository.save(animation);
                     System.out.println("Saved animation: " + animation.getName());
 
-                    animationDirectorService.saveAnimationDirectors(animationId);
 
+
+
+                    List<Animation> similarAnimations = similarAnimationService.getSimilarAnimations(animationId);
+
+                    for (Animation similarAnimation : similarAnimations) {
+                        if (!animationRepository.existsById(similarAnimation.getId())) {
+                            similarAnimation.setBackDropPath(similarAnimation.getBackDropPath());
+                            animationRepository.save(similarAnimation);
+                            System.out.println("Saved recommended animation: " + similarAnimation.getName());
+                        }
+                        animationDirectorService.saveAnimationDirectors(animationId);
+                    }
                     animations.add(animation);
                 }
             } catch (Exception e) {

--- a/CineHive/src/main/java/com/example/CineHive/service/credit/animation/AnimationService.java
+++ b/CineHive/src/main/java/com/example/CineHive/service/credit/animation/AnimationService.java
@@ -93,6 +93,15 @@ public class AnimationService {
                     LocalDate releaseDate = LocalDate.parse(releaseDateString, formatter);
                     animation.setReleaseDate(releaseDate);
 
+                    String movieDetailsResponse = webClient.get()
+                            .uri("https://api.themoviedb.org/3/movie/" + animationId + "?api_key=" + apiKey + "&language=ko")
+                            .retrieve()
+                            .bodyToMono(String.class)
+                            .block();
+
+                    JsonNode movieDetailsNode = objectMapper.readTree(movieDetailsResponse);
+                    int runtime = movieDetailsNode.get("runtime").asInt();
+                    animation.setRuntime(runtime);
 
                     List<Genre> genres = new ArrayList<>();
                     for (JsonNode genreNode : animationNode.get("genre_ids")) {

--- a/CineHive/src/main/java/com/example/CineHive/service/credit/animation/SimilarAnimationService.java
+++ b/CineHive/src/main/java/com/example/CineHive/service/credit/animation/SimilarAnimationService.java
@@ -1,6 +1,7 @@
 package com.example.CineHive.service.credit.animation;
 
 import com.example.CineHive.dto.video.animation.VideoDto;
+
 import com.example.CineHive.entity.videotype.Animation;
 import com.example.CineHive.entity.videotype.RecommendationAnimation;
 import com.example.CineHive.repository.videos.animation.AnimationRecommendationRepository;

--- a/CineHive/src/main/java/com/example/CineHive/service/credit/animation/SimilarAnimationService.java
+++ b/CineHive/src/main/java/com/example/CineHive/service/credit/animation/SimilarAnimationService.java
@@ -1,0 +1,125 @@
+package com.example.CineHive.service.credit.animation;
+
+import com.example.CineHive.dto.video.animation.VideoDto;
+import com.example.CineHive.entity.videotype.Animation;
+import com.example.CineHive.entity.videotype.RecommendationAnimation;
+import com.example.CineHive.repository.videos.animation.AnimationRecommendationRepository;
+import com.example.CineHive.repository.videos.animation.AnimationRepository;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class SimilarAnimationService {
+    @Value("${tmdb.api.key}")
+    private String apiKey;
+
+    @Autowired
+    private AnimationRepository animationRepository;
+
+    @Autowired
+    private AnimationRecommendationRepository animationRecommendationRepository;
+
+    private final WebClient webClient;
+    private final ObjectMapper objectMapper;
+    @Autowired
+    private AnimationVideoService animationVideoService;
+    @Autowired
+    private AnimationDirectorService animationDirectorService;
+
+    public SimilarAnimationService(WebClient.Builder webClientBuilder, ObjectMapper objectMapper) {
+        this.webClient = webClientBuilder.baseUrl("https://api.themoviedb.org/3").build();
+        this.objectMapper = objectMapper;
+    }
+
+    public void saveRecommendedAnimations(Long animationId, List<Animation> similarAnimations) {
+        Animation animation = animationRepository.findById(animationId)
+                .orElseThrow(() -> new RuntimeException("Animation not found"));
+
+        for (Animation similarAnimation : similarAnimations) {
+            Optional<Animation> existingRecommendedAnimation = animationRepository.findById(similarAnimation.getId());
+            if (existingRecommendedAnimation.isPresent()) {
+                RecommendationAnimation recommendationAnimation = new RecommendationAnimation();
+                recommendationAnimation.setAnimation(animation);
+                recommendationAnimation.setRecommendedAnimation(existingRecommendedAnimation.get());
+                animationRecommendationRepository.save(recommendationAnimation);
+            }
+        }
+    }
+
+    public List<Animation> getSimilarAnimations(Long animationId) {
+        String url = "https://api.themoviedb.org/3/movie/" + animationId + "/similar?api_key=" + apiKey + "&language=ko&page=1";
+
+        String response = webClient.get()
+                .uri(url)
+                .header("Accept", "application/json")
+                .retrieve()
+                .bodyToMono(String.class)
+                .block();
+
+        List<Animation> similarAnimations = new ArrayList<>();
+        if (response != null) {
+            try {
+                JsonNode rootNode = objectMapper.readTree(response);
+                JsonNode resultsNode = rootNode.path("results");
+
+                for (int i = 0; i < Math.min(10, resultsNode.size()); i++) {
+                    JsonNode animationNode = resultsNode.get(i);
+                    Animation animation = new Animation();
+                    animation.setId(animationNode.get("id").asLong());
+                    animation.setName(animationNode.get("title").asText());
+                    animation.setOverview(animationNode.get("overview").asText());
+                    animation.setPosterPath(animationNode.get("poster_path").asText());
+                    animation.setVoteAverage(animationNode.get("vote_average").asDouble());
+                    animation.setPopularity(animationNode.get("popularity").asDouble());
+
+                    String releaseDateString = animationNode.get("release_date").asText();
+                    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+                    LocalDate releaseDate = LocalDate.parse(releaseDateString, formatter);
+                    animation.setReleaseDate(releaseDate);
+                    animation.setBackDropPath(animationNode.get("backdrop_path").asText());
+
+                    String movieDetailsResponse = webClient.get()
+                            .uri("https://api.themoviedb.org/3/movie/" + animation.getId() + "?api_key=" + apiKey + "&language=ko")
+                            .retrieve()
+                            .bodyToMono(String.class)
+                            .block();
+
+                    JsonNode movieDetailsNode = objectMapper.readTree(movieDetailsResponse);
+                    JsonNode runtimeNode = movieDetailsNode.get("runtime");
+                    animation.setRuntime(runtimeNode != null && !runtimeNode.isNull() ? runtimeNode.asInt() : 0);
+
+                    animationDirectorService.saveAnimationDirectors(animationId);
+
+
+                    // 비디오 정보 추가
+                    VideoDto video = animationVideoService.getFirstVideoForAnimation(animation.getId());
+                    animation.setVideos(video != null ? List.of() : new ArrayList<>());
+
+                    similarAnimations.add(animation);
+                }
+
+                similarAnimations.sort(Comparator.comparingDouble(Animation::getPopularity).reversed()
+                        .thenComparing(Comparator.comparingDouble(Animation::getVoteAverage).reversed())
+                        .thenComparing(Comparator.comparing(Animation::getReleaseDate).reversed()));
+
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+
+            saveRecommendedAnimations(animationId, similarAnimations);
+        }
+
+        return similarAnimations;
+    }
+}

--- a/CineHive/src/main/java/com/example/CineHive/service/credit/movie/MovieService.java
+++ b/CineHive/src/main/java/com/example/CineHive/service/credit/movie/MovieService.java
@@ -42,6 +42,10 @@ public class MovieService {
 
     @Autowired
     private MovieGenreService movieGenreService;
+
+    @Autowired
+    private SimilarMovieService similarMovieService;
+
     @Autowired
     public MovieService(WebClient.Builder webClientBuilder, ObjectMapper objectMapper) {
         this.webClient = webClientBuilder.baseUrl("https://api.themoviedb.org/3").build();
@@ -130,6 +134,19 @@ public class MovieService {
                     if (!movieRepository.existsById(movieId)) {
                         movieRepository.save(movie);
                         System.out.println("Saved new movie: " + movie.getTitle());
+
+                        // 추천 영화 가져오기
+                        List<Movie> similarMovies = similarMovieService.getSimilarMovies(movieId);
+
+                        // 추천 영화 저장
+                        for (Movie similarMovie : similarMovies) {
+                            if (!movieRepository.existsById(similarMovie.getId())) {
+                                similarMovie.setBackDropPath(similarMovie.getBackDropPath()); // 필요 시 추가 정보 설정
+                                movieRepository.save(similarMovie);
+                                System.out.println("Saved recommended movie: " + similarMovie.getTitle());
+                            }
+                        }
+
                         // 배우 정보
                         movieActorService.saveMovieCredits(movieId);
                         // 감독 정보

--- a/CineHive/src/main/java/com/example/CineHive/service/credit/movie/MovieService.java
+++ b/CineHive/src/main/java/com/example/CineHive/service/credit/movie/MovieService.java
@@ -144,18 +144,18 @@ public class MovieService {
                                 similarMovie.setBackDropPath(similarMovie.getBackDropPath()); // 필요 시 추가 정보 설정
                                 movieRepository.save(similarMovie);
                                 System.out.println("Saved recommended movie: " + similarMovie.getTitle());
+
+                                // 배우 정보
+                                movieActorService.saveMovieCredits(movieId);
+                                // 감독 정보
+                                movieDirectorService.saveMovieDirectors(movieId);
                             }
                         }
 
-                        // 배우 정보
-                        movieActorService.saveMovieCredits(movieId);
-                        // 감독 정보
-                        movieDirectorService.saveMovieDirectors(movieId);
                     } else {
                         System.out.println("Movie already exists: " + movie.getTitle());
                     }
 
-                    // 데이터베이스와 상관없이 항상 리스트에 추가
                     movies.add(movie);
                 }
             } catch (Exception e) {

--- a/CineHive/src/main/java/com/example/CineHive/service/credit/movie/MovieService.java
+++ b/CineHive/src/main/java/com/example/CineHive/service/credit/movie/MovieService.java
@@ -69,6 +69,7 @@ public class MovieService {
                 for (JsonNode movieNode : moviesNode) {
                     Long movieId = movieNode.get("id").asLong();
                     String posterPath = movieNode.get("poster_path").asText();
+                    String backdropPath = movieNode.get("backdrop_path").asText(); // 추가
 
                     if (posterPath == null || posterPath.isEmpty()) {
                         continue;
@@ -79,7 +80,7 @@ public class MovieService {
                     movie.setTitle(movieNode.get("title").asText());
                     movie.setOverview(movieNode.get("overview").asText());
                     movie.setPosterPath(posterPath);
-
+                    movie.setBackDropPath(backdropPath); // 추가
 
                     List<Genre> genres = new ArrayList<>();
                     for (JsonNode genreIdNode : movieNode.get("genre_ids")) {
@@ -97,10 +98,11 @@ public class MovieService {
                     LocalDate releaseDate = LocalDate.parse(releaseDateString, formatter);
                     movie.setReleaseDate(releaseDate);
 
-                    // 애니메이션 장르 제외
+
                     if (movie.getGenres().stream().anyMatch(g -> g.getId() == 16)) {
                         continue;
                     }
+
 
                     String movieDetailsResponse = webClient.get()
                             .uri("https://api.themoviedb.org/3/movie/" + movieId + "?api_key=" + apiKey + "&language=ko")
@@ -116,7 +118,7 @@ public class MovieService {
                         movie.setRuntime(0);
                     }
 
-                    // 비디오 정보 가져오기 (첫 번째 비디오만)
+
                     Video video = movieVideoService.getFirstVideoForMovie(movieId);
                     if (video != null) {
                         movie.setVideos(List.of(video)); // 비디오 정보를 리스트로 설정
@@ -147,5 +149,6 @@ public class MovieService {
         }
         return movies;
     }
+
 
 }

--- a/CineHive/src/main/java/com/example/CineHive/service/credit/movie/NowPlayingMovieService.java
+++ b/CineHive/src/main/java/com/example/CineHive/service/credit/movie/NowPlayingMovieService.java
@@ -147,8 +147,6 @@ public class NowPlayingMovieService {
                             movie.setVideos(new ArrayList<>());
                         }
                         movieRepository.save(movie);
-                        System.out.println("Saved movie to Movie table: " + movie.getTitle());
-
 
                         List<Movie> similarMovies = similarMovieService.getSimilarMovies(movieId);
 
@@ -158,12 +156,14 @@ public class NowPlayingMovieService {
                                 similarMovie.setBackDropPath(similarMovie.getBackDropPath()); // 필요 시 추가 정보 설정
                                 movieRepository.save(similarMovie);
                                 System.out.println("Saved recommended movie: " + similarMovie.getTitle());
+
+
+                                movieActorService.saveMovieCredits(similarMovie.getId());
+                                movieDirectorService.saveMovieDirectors(similarMovie.getId());
                             }
                         }
 
-                        movieActorService.saveMovieCredits(movieId);
 
-                        movieDirectorService.saveMovieDirectors(movieId);
                     }
                 }
             } catch (Exception e) {

--- a/CineHive/src/main/java/com/example/CineHive/service/credit/movie/NowPlayingMovieService.java
+++ b/CineHive/src/main/java/com/example/CineHive/service/credit/movie/NowPlayingMovieService.java
@@ -44,6 +44,8 @@ public class NowPlayingMovieService {
     private MovieGenreService movieGenreService;
     @Autowired
     private MovieVideoService movieVideoService;
+    @Autowired
+    private SimilarMovieService similarMovieService;
 
 
 
@@ -147,6 +149,17 @@ public class NowPlayingMovieService {
                         movieRepository.save(movie);
                         System.out.println("Saved movie to Movie table: " + movie.getTitle());
 
+
+                        List<Movie> similarMovies = similarMovieService.getSimilarMovies(movieId);
+
+                        // 추천 영화 저장
+                        for (Movie similarMovie : similarMovies) {
+                            if (!movieRepository.existsById(similarMovie.getId())) {
+                                similarMovie.setBackDropPath(similarMovie.getBackDropPath()); // 필요 시 추가 정보 설정
+                                movieRepository.save(similarMovie);
+                                System.out.println("Saved recommended movie: " + similarMovie.getTitle());
+                            }
+                        }
 
                         movieActorService.saveMovieCredits(movieId);
 

--- a/CineHive/src/main/java/com/example/CineHive/service/credit/movie/PopularMovieService.java
+++ b/CineHive/src/main/java/com/example/CineHive/service/credit/movie/PopularMovieService.java
@@ -159,8 +159,8 @@ public class PopularMovieService {
                                 movieRepository.save(similarMovie);
                                 System.out.println("Saved recommended movie: " + similarMovie.getTitle());
 
-                                movieActorService.saveMovieCredits(movieId);
-                                movieDirectorService.saveMovieDirectors(movieId);
+                                movieActorService.saveMovieCredits(similarMovie.getId());
+                                movieDirectorService.saveMovieDirectors(similarMovie.getId());
                             }
                         }
 

--- a/CineHive/src/main/java/com/example/CineHive/service/credit/movie/PopularMovieService.java
+++ b/CineHive/src/main/java/com/example/CineHive/service/credit/movie/PopularMovieService.java
@@ -129,7 +129,7 @@ public class PopularMovieService {
                         popularRepository.save(popularMovie);
                         System.out.println("Saved movie: " + popularMovie.getTitle());
 
-                        // Movie 객체 생성 및 저장
+
                         Movie movie = new Movie();
                         movie.setId(movieId);
                         movie.setTitle(popularMovie.getTitle());
@@ -147,25 +147,23 @@ public class PopularMovieService {
                         } else {
                             movie.setVideos(new ArrayList<>());
                         }
-                        // Movie 데이터베이스에 저장
-
-
 
                         movieRepository.save(movie);
 
-
                         List<Movie> similarMovies = similarMovieService.getSimilarMovies(movieId);
 
-                        // 추천 영화 저장
+
                         for (Movie similarMovie : similarMovies) {
                             if (!movieRepository.existsById(similarMovie.getId())) {
                                 similarMovie.setBackDropPath(similarMovie.getBackDropPath()); // 필요 시 추가 정보 설정
                                 movieRepository.save(similarMovie);
                                 System.out.println("Saved recommended movie: " + similarMovie.getTitle());
+
+                                movieActorService.saveMovieCredits(movieId);
+                                movieDirectorService.saveMovieDirectors(movieId);
                             }
                         }
-                        movieActorService.saveMovieCredits(movieId);
-                        movieDirectorService.saveMovieDirectors(movieId);
+
                         System.out.println("Saved movie to Movie table: " + movie.getTitle());
                     }
                 }

--- a/CineHive/src/main/java/com/example/CineHive/service/credit/movie/PopularMovieService.java
+++ b/CineHive/src/main/java/com/example/CineHive/service/credit/movie/PopularMovieService.java
@@ -48,6 +48,8 @@ public class PopularMovieService {
 
     @Autowired
     private MovieVideoService movieVideoService;
+    @Autowired
+    private SimilarMovieService similarMovieService;
 
     public PopularMovieService(WebClient.Builder webClientBuilder, ObjectMapper objectMapper) {
         this.webClient = webClientBuilder.baseUrl("https://api.themoviedb.org/3").build();
@@ -146,8 +148,22 @@ public class PopularMovieService {
                             movie.setVideos(new ArrayList<>());
                         }
                         // Movie 데이터베이스에 저장
+
+
+
                         movieRepository.save(movie);
 
+
+                        List<Movie> similarMovies = similarMovieService.getSimilarMovies(movieId);
+
+                        // 추천 영화 저장
+                        for (Movie similarMovie : similarMovies) {
+                            if (!movieRepository.existsById(similarMovie.getId())) {
+                                similarMovie.setBackDropPath(similarMovie.getBackDropPath()); // 필요 시 추가 정보 설정
+                                movieRepository.save(similarMovie);
+                                System.out.println("Saved recommended movie: " + similarMovie.getTitle());
+                            }
+                        }
                         movieActorService.saveMovieCredits(movieId);
                         movieDirectorService.saveMovieDirectors(movieId);
                         System.out.println("Saved movie to Movie table: " + movie.getTitle());

--- a/CineHive/src/main/java/com/example/CineHive/service/credit/movie/SimilarMovieService.java
+++ b/CineHive/src/main/java/com/example/CineHive/service/credit/movie/SimilarMovieService.java
@@ -14,6 +14,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -31,12 +32,12 @@ public class SimilarMovieService {
     private final ObjectMapper objectMapper;
 
     @Autowired
-    private MovieRecommendationRepository movieRecommendationRepository;
-
+    private MovieDirectorService movieDirectorService;
     @Autowired
     private MovieActorService movieActorService;
+
     @Autowired
-    private MovieDirectorService movieDirectorService;
+    private MovieRecommendationRepository movieRecommendationRepository;
 
     @Autowired
     private MovieVideoService movieVideoService;
@@ -47,6 +48,11 @@ public class SimilarMovieService {
     }
 
     public void saveRecommendedMovies(Long movieId, List<Movie> similarMovies) {
+        Optional<Movie> existingMovie = movieRepository.findById(movieId);
+        if (existingMovie.isEmpty()) {
+            System.out.println("Movie with ID " + movieId + " not found in the Movie table.");
+        }
+
         Movie movie = movieRepository.findById(movieId).orElseThrow(() -> new RuntimeException("Movie not found"));
 
         for (Movie similarMovie : similarMovies) {
@@ -62,6 +68,7 @@ public class SimilarMovieService {
     }
 
     public List<Movie> getSimilarMovies(Long movieId) {
+
         String url = "https://api.themoviedb.org/3/movie/" + movieId + "/similar?api_key=" + apiKey + "&language=ko&page=1";
 
         String response = webClient.get()
@@ -88,12 +95,20 @@ public class SimilarMovieService {
                     movie.setPopularity(movieNode.get("popularity").asDouble());
 
                     String releaseDateString = movieNode.get("release_date").asText();
-                    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
-                    LocalDate releaseDate = LocalDate.parse(releaseDateString, formatter);
+                    LocalDate releaseDate = null;
+                    if (releaseDateString != null && !releaseDateString.isEmpty()) {
+                        try {
+                            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+                            releaseDate = LocalDate.parse(releaseDateString, formatter);
+                        } catch (DateTimeParseException e) {
+                            e.printStackTrace();
+                            releaseDate = null;
+                        }
+                    }
                     movie.setReleaseDate(releaseDate);
-
                     String backdropPath = movieNode.get("backdrop_path").asText();
                     movie.setBackDropPath(backdropPath);
+
 
                     String movieDetailsResponse = webClient.get()
                             .uri("https://api.themoviedb.org/3/movie/" + movie.getId() + "?api_key=" + apiKey + "&language=ko")
@@ -115,6 +130,7 @@ public class SimilarMovieService {
                     similarMovies.add(movie);
                 }
 
+
                 similarMovies.sort(Comparator.comparingDouble(Movie::getPopularity).reversed()
                         .thenComparing(Comparator.comparingDouble(Movie::getVoteAverage).reversed())
                         .thenComparing(Comparator.comparing(Movie::getReleaseDate).reversed()));
@@ -128,4 +144,5 @@ public class SimilarMovieService {
 
         return similarMovies;
     }
+
 }

--- a/CineHive/src/main/java/com/example/CineHive/service/credit/movie/SimilarMovieService.java
+++ b/CineHive/src/main/java/com/example/CineHive/service/credit/movie/SimilarMovieService.java
@@ -1,0 +1,92 @@
+package com.example.CineHive.service.credit.movie;
+
+import com.example.CineHive.entity.videotype.Movie;
+import com.example.CineHive.entity.videotype.RecommendationMovie;
+import com.example.CineHive.repository.videos.movie.MovieRecommendationRepository;
+import com.example.CineHive.repository.videos.movie.MovieRepository;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class SimilarMovieService {
+    @Value("${tmdb.api.key}")
+    private String apiKey;
+    @Autowired
+    private MovieRepository movieRepository;
+    private final WebClient webClient;
+    private final ObjectMapper objectMapper;
+    @Autowired
+    private MovieRecommendationRepository movieRecommendationRepository;
+
+    public SimilarMovieService(WebClient.Builder webClientBuilder, ObjectMapper objectMapper) {
+        this.webClient = webClientBuilder.baseUrl("https://api.themoviedb.org/3").build();
+        this.objectMapper = objectMapper;
+    }
+
+
+    public void saveRecommendedMovies(Long movieId, List<Movie> similarMovies) {
+        Movie movie = movieRepository.findById(movieId).orElseThrow(() -> new RuntimeException("Movie not found"));
+
+
+        for (Movie similarMovie : similarMovies) {
+
+            Optional<Movie> existingRecommendedMovie = movieRepository.findById(similarMovie.getId());
+            if (existingRecommendedMovie.isPresent()) {
+                RecommendationMovie recommendationMovie = new RecommendationMovie();
+                recommendationMovie.setMovie(movie);
+                recommendationMovie.setRecommendedMovie(existingRecommendedMovie.get());
+
+                // 연결된 추천 영화 저장
+                movieRecommendationRepository.save(recommendationMovie);
+            }
+        }
+    }
+
+
+    public List<Movie> getSimilarMovies(Long movieId) {
+        String url = "https://api.themoviedb.org/3/movie/" + movieId + "/similar?api_key=" + apiKey + "&language=ko&page=1";
+
+        String response = webClient.get()
+                .uri(url)
+                .header("Accept", "application/json")
+                .retrieve()
+                .bodyToMono(String.class)
+                .block();
+
+        List<Movie> similarMovies = new ArrayList<>();
+        if (response != null) {
+            try {
+                JsonNode rootNode = objectMapper.readTree(response);
+                JsonNode moviesNode = rootNode.path("results");
+
+                for (JsonNode movieNode : moviesNode) {
+                    Movie movie = new Movie();
+                    movie.setId(movieNode.get("id").asLong());
+                    movie.setTitle(movieNode.get("title").asText());
+                    movie.setOverview(movieNode.get("overview").asText());
+                    movie.setPosterPath(movieNode.get("poster_path").asText());
+                    movie.setVoteAverage(movieNode.get("vote_average").asDouble());
+                    movie.setPopularity(movieNode.get("popularity").asDouble());
+
+                    similarMovies.add(movie);
+                }
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+
+
+            saveRecommendedMovies(movieId, similarMovies);
+        }
+
+        return similarMovies;
+    }
+
+}

--- a/CineHive/src/main/java/com/example/CineHive/service/credit/movie/SimilarMovieService.java
+++ b/CineHive/src/main/java/com/example/CineHive/service/credit/movie/SimilarMovieService.java
@@ -1,5 +1,6 @@
 package com.example.CineHive.service.credit.movie;
 
+import com.example.CineHive.entity.credit.movie.Video;
 import com.example.CineHive.entity.videotype.Movie;
 import com.example.CineHive.entity.videotype.RecommendationMovie;
 import com.example.CineHive.repository.videos.movie.MovieRecommendationRepository;
@@ -11,6 +12,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -19,37 +22,43 @@ import java.util.Optional;
 public class SimilarMovieService {
     @Value("${tmdb.api.key}")
     private String apiKey;
+
     @Autowired
     private MovieRepository movieRepository;
+
     private final WebClient webClient;
     private final ObjectMapper objectMapper;
+
     @Autowired
     private MovieRecommendationRepository movieRecommendationRepository;
+
+    @Autowired
+    private MovieActorService movieActorService;
+    @Autowired
+    private MovieDirectorService movieDirectorService;
+
+    @Autowired
+    private MovieVideoService movieVideoService;
 
     public SimilarMovieService(WebClient.Builder webClientBuilder, ObjectMapper objectMapper) {
         this.webClient = webClientBuilder.baseUrl("https://api.themoviedb.org/3").build();
         this.objectMapper = objectMapper;
     }
 
-
     public void saveRecommendedMovies(Long movieId, List<Movie> similarMovies) {
         Movie movie = movieRepository.findById(movieId).orElseThrow(() -> new RuntimeException("Movie not found"));
 
-
         for (Movie similarMovie : similarMovies) {
-
             Optional<Movie> existingRecommendedMovie = movieRepository.findById(similarMovie.getId());
             if (existingRecommendedMovie.isPresent()) {
                 RecommendationMovie recommendationMovie = new RecommendationMovie();
                 recommendationMovie.setMovie(movie);
                 recommendationMovie.setRecommendedMovie(existingRecommendedMovie.get());
 
-                // 연결된 추천 영화 저장
                 movieRecommendationRepository.save(recommendationMovie);
             }
         }
     }
-
 
     public List<Movie> getSimilarMovies(Long movieId) {
         String url = "https://api.themoviedb.org/3/movie/" + movieId + "/similar?api_key=" + apiKey + "&language=ko&page=1";
@@ -77,6 +86,41 @@ public class SimilarMovieService {
                     movie.setVoteAverage(movieNode.get("vote_average").asDouble());
                     movie.setPopularity(movieNode.get("popularity").asDouble());
 
+                    String releaseDateString = movieNode.get("release_date").asText();
+                    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+                    LocalDate releaseDate = LocalDate.parse(releaseDateString, formatter);
+                    movie.setReleaseDate(releaseDate);
+
+                    String backdropPath = movieNode.get("backdrop_path").asText();
+                    movie.setBackDropPath(backdropPath);
+
+                    String movieDetailsResponse = webClient.get()
+                            .uri("https://api.themoviedb.org/3/movie/" + movie.getId() + "?api_key=" + apiKey + "&language=ko")
+                            .retrieve()
+                            .bodyToMono(String.class)
+                            .block();
+
+                    JsonNode movieDetailsNode = objectMapper.readTree(movieDetailsResponse);
+
+
+                    JsonNode runtimeNode = movieDetailsNode.get("runtime");
+                    if (runtimeNode != null && !runtimeNode.isNull()) {
+                        movie.setRuntime(runtimeNode.asInt());
+                    } else {
+                        movie.setRuntime(0);
+                    }
+
+                    movieDirectorService.saveMovieDirectors(movieId);
+                    movieActorService.saveMovieCredits(movieId);
+
+                    // 비디오 정보 추가
+                    Video video = movieVideoService.getFirstVideoForMovie(movie.getId());
+                    if (video != null) {
+                        movie.setVideos(List.of(video)); // 비디오 정보 리스트로 설정
+                    } else {
+                        movie.setVideos(new ArrayList<>());
+                    }
+
                     similarMovies.add(movie);
                 }
             } catch (Exception e) {
@@ -88,6 +132,4 @@ public class SimilarMovieService {
 
         return similarMovies;
     }
-
-
 }

--- a/CineHive/src/main/java/com/example/CineHive/service/credit/movie/SimilarMovieService.java
+++ b/CineHive/src/main/java/com/example/CineHive/service/credit/movie/SimilarMovieService.java
@@ -67,7 +67,8 @@ public class SimilarMovieService {
                 JsonNode rootNode = objectMapper.readTree(response);
                 JsonNode moviesNode = rootNode.path("results");
 
-                for (JsonNode movieNode : moviesNode) {
+                for (int i = 0; i < Math.min(10, moviesNode.size()); i++) {
+                    JsonNode movieNode = moviesNode.get(i);
                     Movie movie = new Movie();
                     movie.setId(movieNode.get("id").asLong());
                     movie.setTitle(movieNode.get("title").asText());
@@ -82,11 +83,11 @@ public class SimilarMovieService {
                 e.printStackTrace();
             }
 
-
             saveRecommendedMovies(movieId, similarMovies);
         }
 
         return similarMovies;
     }
+
 
 }

--- a/CineHive/src/main/java/com/example/CineHive/service/credit/movie/SimilarMovieService.java
+++ b/CineHive/src/main/java/com/example/CineHive/service/credit/movie/SimilarMovieService.java
@@ -15,6 +15,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 
@@ -101,28 +102,21 @@ public class SimilarMovieService {
                             .block();
 
                     JsonNode movieDetailsNode = objectMapper.readTree(movieDetailsResponse);
-
-
                     JsonNode runtimeNode = movieDetailsNode.get("runtime");
-                    if (runtimeNode != null && !runtimeNode.isNull()) {
-                        movie.setRuntime(runtimeNode.asInt());
-                    } else {
-                        movie.setRuntime(0);
-                    }
+                    movie.setRuntime(runtimeNode != null && !runtimeNode.isNull() ? runtimeNode.asInt() : 0);
 
                     movieDirectorService.saveMovieDirectors(movieId);
                     movieActorService.saveMovieCredits(movieId);
 
                     // 비디오 정보 추가
                     Video video = movieVideoService.getFirstVideoForMovie(movie.getId());
-                    if (video != null) {
-                        movie.setVideos(List.of(video)); // 비디오 정보 리스트로 설정
-                    } else {
-                        movie.setVideos(new ArrayList<>());
-                    }
+                    movie.setVideos(video != null ? List.of(video) : new ArrayList<>());
 
                     similarMovies.add(movie);
                 }
+
+                similarMovies.sort(Comparator.comparingDouble(Movie::getPopularity).reversed());
+
             } catch (Exception e) {
                 e.printStackTrace();
             }

--- a/CineHive/src/main/java/com/example/CineHive/service/credit/movie/SimilarMovieService.java
+++ b/CineHive/src/main/java/com/example/CineHive/service/credit/movie/SimilarMovieService.java
@@ -115,7 +115,9 @@ public class SimilarMovieService {
                     similarMovies.add(movie);
                 }
 
-                similarMovies.sort(Comparator.comparingDouble(Movie::getPopularity).reversed());
+                similarMovies.sort(Comparator.comparingDouble(Movie::getPopularity).reversed()
+                        .thenComparing(Comparator.comparingDouble(Movie::getVoteAverage).reversed())
+                        .thenComparing(Comparator.comparing(Movie::getReleaseDate).reversed()));
 
             } catch (Exception e) {
                 e.printStackTrace();

--- a/CineHive/src/main/java/com/example/CineHive/service/credit/movie/TopRatedMovieService.java
+++ b/CineHive/src/main/java/com/example/CineHive/service/credit/movie/TopRatedMovieService.java
@@ -81,7 +81,6 @@ public class TopRatedMovieService {
                 for (JsonNode movieNode : moviesNode) {
                     Long movieId = movieNode.get("id").asLong();
 
-                    // 영화가 이미 존재하는지 확인
                     if (!topMovieRepository.existsById(movieId)) {
                         TopMovie topmovie = new TopMovie();
                         topmovie.setId(movieId);
@@ -96,7 +95,6 @@ public class TopRatedMovieService {
                         LocalDate releaseDate = LocalDate.parse(releaseDateString, formatter);
                         topmovie.setReleaseDate(releaseDate);
 
-                        // 영화 상세 정보 가져오기
                         String movieDetailsResponse = webClient.get()
                                 .uri("https://api.themoviedb.org/3/movie/" + movieId + "?api_key=" + apiKey + "&language=ko")
                                 .retrieve()
@@ -120,11 +118,9 @@ public class TopRatedMovieService {
                         }
                         topmovie.setGenres(genres);
 
-
                         topMovieRepository.save(topmovie);
                         System.out.println("Saved movie: " + topmovie.getTitle());
 
-                        // Movie 객체 생성 및 저장
                         Movie movie = new Movie();
                         movie.setId(movieId);
                         movie.setTitle(topmovie.getTitle());
@@ -143,8 +139,6 @@ public class TopRatedMovieService {
                             movie.setVideos(new ArrayList<>());
                         }
 
-
-                        // Movie 데이터베이스에 저장
                         movieRepository.save(movie);
 
                         List<Movie> similarMovies = similarMovieService.getSimilarMovies(movieId);
@@ -155,10 +149,12 @@ public class TopRatedMovieService {
                                 similarMovie.setBackDropPath(similarMovie.getBackDropPath()); // 필요 시 추가 정보 설정
                                 movieRepository.save(similarMovie);
                                 System.out.println("Saved recommended movie: " + similarMovie.getTitle());
+
+                                movieActorService.saveMovieCredits(movieId);
+                                movieDirectorService.saveMovieDirectors(movieId);
                             }
                         }
-                        movieActorService.saveMovieCredits(movieId);
-                        movieDirectorService.saveMovieDirectors(movieId);
+
                         System.out.println("Saved movie to Movie table: " + movie.getTitle());
                     }
                 }

--- a/CineHive/src/main/java/com/example/CineHive/service/credit/movie/TopRatedMovieService.java
+++ b/CineHive/src/main/java/com/example/CineHive/service/credit/movie/TopRatedMovieService.java
@@ -150,8 +150,8 @@ public class TopRatedMovieService {
                                 movieRepository.save(similarMovie);
                                 System.out.println("Saved recommended movie: " + similarMovie.getTitle());
 
-                                movieActorService.saveMovieCredits(movieId);
-                                movieDirectorService.saveMovieDirectors(movieId);
+                                movieActorService.saveMovieCredits(similarMovie.getId());
+                                movieDirectorService.saveMovieDirectors(similarMovie.getId());
                             }
                         }
 

--- a/CineHive/src/main/java/com/example/CineHive/service/credit/movie/TopRatedMovieService.java
+++ b/CineHive/src/main/java/com/example/CineHive/service/credit/movie/TopRatedMovieService.java
@@ -43,6 +43,8 @@ public class TopRatedMovieService {
     private MovieGenreService movieGenreService;
     @Autowired
     private MovieVideoService movieVideoService;
+    @Autowired
+    private SimilarMovieService similarMovieService;
 
     private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 
@@ -141,9 +143,20 @@ public class TopRatedMovieService {
                             movie.setVideos(new ArrayList<>());
                         }
 
+
                         // Movie 데이터베이스에 저장
                         movieRepository.save(movie);
 
+                        List<Movie> similarMovies = similarMovieService.getSimilarMovies(movieId);
+
+                        // 추천 영화 저장
+                        for (Movie similarMovie : similarMovies) {
+                            if (!movieRepository.existsById(similarMovie.getId())) {
+                                similarMovie.setBackDropPath(similarMovie.getBackDropPath()); // 필요 시 추가 정보 설정
+                                movieRepository.save(similarMovie);
+                                System.out.println("Saved recommended movie: " + similarMovie.getTitle());
+                            }
+                        }
                         movieActorService.saveMovieCredits(movieId);
                         movieDirectorService.saveMovieDirectors(movieId);
                         System.out.println("Saved movie to Movie table: " + movie.getTitle());

--- a/CineHive/src/main/java/com/example/CineHive/service/credit/movie/UpComingMovieService.java
+++ b/CineHive/src/main/java/com/example/CineHive/service/credit/movie/UpComingMovieService.java
@@ -48,6 +48,9 @@ public class UpComingMovieService {
     @Autowired
     private MovieVideoService movieVideoService;
 
+    @Autowired
+    private SimilarMovieService similarMovieService;
+
     private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 
     @Scheduled(cron = "0 0 3 * * *")
@@ -143,6 +146,16 @@ public class UpComingMovieService {
                         // Movie 데이터베이스에 저장
                         movieRepository.save(movie);
 
+                        List<Movie> similarMovies = similarMovieService.getSimilarMovies(movieId);
+
+                        // 추천 영화 저장
+                        for (Movie similarMovie : similarMovies) {
+                            if (!movieRepository.existsById(similarMovie.getId())) {
+                                similarMovie.setBackDropPath(similarMovie.getBackDropPath()); // 필요 시 추가 정보 설정
+                                movieRepository.save(similarMovie);
+                                System.out.println("Saved recommended movie: " + similarMovie.getTitle());
+                            }
+                        }
                         movieActorService.saveMovieCredits(movieId);
                         movieDirectorService.saveMovieDirectors(movieId);
                         System.out.println("Saved movie to Movie table: " + movie.getTitle());

--- a/CineHive/src/main/java/com/example/CineHive/service/credit/movie/UpComingMovieService.java
+++ b/CineHive/src/main/java/com/example/CineHive/service/credit/movie/UpComingMovieService.java
@@ -149,8 +149,8 @@ public class UpComingMovieService {
                                 movieRepository.save(similarMovie);
                                 System.out.println("Saved recommended movie: " + similarMovie.getTitle());
 
-                                movieActorService.saveMovieCredits(movieId);
-                                movieDirectorService.saveMovieDirectors(movieId);
+                                movieActorService.saveMovieCredits(similarMovie.getId());
+                                movieDirectorService.saveMovieDirectors(similarMovie.getId());
                             }
                         }
 

--- a/CineHive/src/main/java/com/example/CineHive/service/credit/movie/UpComingMovieService.java
+++ b/CineHive/src/main/java/com/example/CineHive/service/credit/movie/UpComingMovieService.java
@@ -62,7 +62,6 @@ public class UpComingMovieService {
         System.out.println("[" + currentTime + "] [자동 업데이트]개봉 예정 영화 업데이트 완료!");
     }
 
-
     @Transactional
     public void saveUpComingMoviesToDatabase() {
         // API를 호출하여 데이터를 가져옵니다.
@@ -81,7 +80,6 @@ public class UpComingMovieService {
                 for (JsonNode movieNode : moviesNode) {
                     Long movieId = movieNode.get("id").asLong();
 
-                    // 영화가 이미 존재하는지 확인
                     if (!upComingRepository.existsById(movieId)) {
                         UpComingMovie upComingMovie = new UpComingMovie();
                         upComingMovie.setId(movieId);
@@ -96,7 +94,6 @@ public class UpComingMovieService {
                         LocalDate releaseDate = LocalDate.parse(releaseDateString, formatter);
                         upComingMovie.setReleaseDate(releaseDate);
 
-                        // 영화 상세 정보 가져오기
                         String movieDetailsResponse = webClient.get()
                                 .uri("https://api.themoviedb.org/3/movie/" + movieId + "?api_key=" + apiKey + "&language=ko")
                                 .retrieve()
@@ -124,7 +121,6 @@ public class UpComingMovieService {
                         upComingRepository.save(upComingMovie);
                         System.out.println("Saved movie: " + upComingMovie.getTitle());
 
-                        // Movie 객체 생성 및 저장
                         Movie movie = new Movie();
                         movie.setId(movieId);
                         movie.setTitle(upComingMovie.getTitle());
@@ -143,21 +139,21 @@ public class UpComingMovieService {
                             movie.setVideos(new ArrayList<>());
                         }
 
-                        // Movie 데이터베이스에 저장
                         movieRepository.save(movie);
 
                         List<Movie> similarMovies = similarMovieService.getSimilarMovies(movieId);
 
-                        // 추천 영화 저장
                         for (Movie similarMovie : similarMovies) {
                             if (!movieRepository.existsById(similarMovie.getId())) {
                                 similarMovie.setBackDropPath(similarMovie.getBackDropPath()); // 필요 시 추가 정보 설정
                                 movieRepository.save(similarMovie);
                                 System.out.println("Saved recommended movie: " + similarMovie.getTitle());
+
+                                movieActorService.saveMovieCredits(movieId);
+                                movieDirectorService.saveMovieDirectors(movieId);
                             }
                         }
-                        movieActorService.saveMovieCredits(movieId);
-                        movieDirectorService.saveMovieDirectors(movieId);
+
                         System.out.println("Saved movie to Movie table: " + movie.getTitle());
                     }
                 }


### PR DESCRIPTION
## 작업 내용
- 특정 영화 조회 시 영화와  관련있는 추천 영화 리스트를 제공해주도록 기능 구현
- 특정 애니메이션 조회 시 애니메이션과 관련 있는 추천 애니메이션 리스트를 제공해주도록 기능 구현
- 애니메이션 상세 정보에 대해 상영 시간(`runtime`) 데이터 추가

## PR Point
- 현재 상영중인 영화, 인기 영화, 평점 순 영화, 개봉 예정인 영화에 대해 저장을 할 때, 동시에 관련 추천 영화를 저장하도록 로직을 구성 ( `마찬가지로 redis 인메모리 캐싱으로 개선 필요` )
- 관련 추천 영화 엔드 포인트 → `/movies/{id}/similar`
- 관련 애니메이션 영화 엔드 포인트 → `/animations/{id}/similar`
- 관련 추천 영화 및 애니메이션 리스트 정보는 인기도, 평점, 최신성을 조합하여 정렬해서 상위 10개만 보여주도록 정보를 제공

## 스크린샷
X