### PR TITLE
[feature/ott service] : OTT 플랫폼 인기 콘텐츠 정보 제공 기능 구현

### DIFF
--- a/CineHive/src/main/java/com/example/CineHive/config/SecurityConfig.java
+++ b/CineHive/src/main/java/com/example/CineHive/config/SecurityConfig.java
@@ -49,7 +49,8 @@ public class SecurityConfig {
                                 "/report/{boardId}",
                                 "/comment/{boardId}","/comment/{boardId}/**"
                         ,"/boards/search","/update_now_playing","/update_top_movie","/get_upcoming_movies","/update_upcoming_movie",
-                                "/update_popular_movie","/get_popular_movies","/movies/{id}/similar").permitAll()
+                                "/update_popular_movie","/get_popular_movies","/movies/{id}/similar",
+                                "api/ott/**").permitAll()
                         .requestMatchers("/login", "/register", "/checkuserId/**","/checknickname/**","/checkemail/**",
                                 "/api/auth/kakao/check-user","/api/auth/kakao/register",
                                 "/api/auth/google/register","/api/auth/google/check-user","/api/auth/naver/check-user","/api/auth/naver/register").permitAll() // 로그인과 회원가입은 누구나 접근 가능

--- a/CineHive/src/main/java/com/example/CineHive/config/SecurityConfig.java
+++ b/CineHive/src/main/java/com/example/CineHive/config/SecurityConfig.java
@@ -1,8 +1,6 @@
 package com.example.CineHive.config;
 
 import com.example.CineHive.filter.JwtRequestFilter;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -10,11 +8,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.web.cors.CorsConfiguration;
-import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
-import org.springframework.web.filter.CorsFilter;
 
-import java.util.Arrays;
 
 @Configuration
 @EnableWebSecurity

--- a/CineHive/src/main/java/com/example/CineHive/config/WebConfig.java
+++ b/CineHive/src/main/java/com/example/CineHive/config/WebConfig.java
@@ -1,6 +1,5 @@
 package com.example.CineHive.config;
 
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -10,11 +9,11 @@ public class WebConfig implements WebMvcConfigurer{
 
             @Override
             public void addCorsMappings(CorsRegistry registry) {
-                registry.addMapping("/**")  // 모든 경로에 대해 CORS 허용
-                        .allowedOrigins("http://localhost:8080")  // 허용할 출처
-                        .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH")  // 허용할 HTTP 메소드
-                        .allowedHeaders("*")  // 모든 헤더 허용
-                        .allowCredentials(true);  // 자격 증명 허용 (쿠키 등)
+                registry.addMapping("/**")
+                        .allowedOrigins("http://localhost:8080")
+                        .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH")
+                        .allowedHeaders("*")
+                        .allowCredentials(true);
             }
 }
 

--- a/CineHive/src/main/java/com/example/CineHive/controller/ott/OttController.java
+++ b/CineHive/src/main/java/com/example/CineHive/controller/ott/OttController.java
@@ -1,0 +1,24 @@
+package com.example.CineHive.controller.ott;
+
+import com.example.CineHive.dto.ott.OttDto;
+import com.example.CineHive.service.ott.OttService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+
+@RestController
+@RequestMapping("/api/ott")
+@RequiredArgsConstructor
+public class OttController {
+
+    private final OttService ottService;
+
+    @GetMapping("/{providerId}")
+    public ResponseEntity<List<OttDto>> getMoviesByProvider(@PathVariable int providerId) {
+        List<OttDto> movies = ottService.getMoviesByProvider(providerId);
+        return ResponseEntity.ok(movies);
+    }
+}

--- a/CineHive/src/main/java/com/example/CineHive/dto/ott/MovieResponseDto.java
+++ b/CineHive/src/main/java/com/example/CineHive/dto/ott/MovieResponseDto.java
@@ -1,0 +1,32 @@
+package com.example.CineHive.dto.ott;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MovieResponseDto {
+    private String title;
+    private String overview;
+    @JsonProperty("poster_path")
+    private String posterPath;
+    private Double popularity;
+    @JsonProperty("release_date")
+    private LocalDate releaseDate;
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MovieList {
+        private List<MovieResponseDto> results;
+    }
+}

--- a/CineHive/src/main/java/com/example/CineHive/dto/ott/OttDto.java
+++ b/CineHive/src/main/java/com/example/CineHive/dto/ott/OttDto.java
@@ -20,4 +20,3 @@ public class OttDto {
     private LocalDate releaseDate;
     private ProviderDto provider;
 }
-d

--- a/CineHive/src/main/java/com/example/CineHive/dto/ott/OttDto.java
+++ b/CineHive/src/main/java/com/example/CineHive/dto/ott/OttDto.java
@@ -1,0 +1,23 @@
+package com.example.CineHive.dto.ott;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class OttDto {
+    private Long id;
+    private String title;
+    private String overview;
+    private String posterPath;
+    private Double popularity;
+    private LocalDate releaseDate;
+    private ProviderDto provider;
+}
+d

--- a/CineHive/src/main/java/com/example/CineHive/dto/ott/ProviderDto.java
+++ b/CineHive/src/main/java/com/example/CineHive/dto/ott/ProviderDto.java
@@ -1,0 +1,15 @@
+package com.example.CineHive.dto.ott;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProviderDto {
+    private Integer id;
+    private String name;
+}

--- a/CineHive/src/main/java/com/example/CineHive/entity/ott/Ott.java
+++ b/CineHive/src/main/java/com/example/CineHive/entity/ott/Ott.java
@@ -1,0 +1,33 @@
+package com.example.CineHive.entity.ott;
+
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class Ott {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+    @Column(columnDefinition = "TEXT")
+    private String overview;
+    private String posterPath;
+    private Double popularity;
+    private LocalDate releaseDate;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "provider_id")
+    private Provider provider;
+}

--- a/CineHive/src/main/java/com/example/CineHive/entity/ott/Provider.java
+++ b/CineHive/src/main/java/com/example/CineHive/entity/ott/Provider.java
@@ -1,0 +1,27 @@
+package com.example.CineHive.entity.ott;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class Provider {
+
+    @Id
+    private Integer id;
+    private String name;
+
+    @OneToMany(mappedBy = "provider", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Ott> otts;
+}

--- a/CineHive/src/main/java/com/example/CineHive/entity/videotype/Movie.java
+++ b/CineHive/src/main/java/com/example/CineHive/entity/videotype/Movie.java
@@ -33,6 +33,7 @@ public class Movie {
     @Column(name = "release_date")
     private LocalDate releaseDate;
 
+    private int ott;
 
     @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     @JoinColumn(name = "movie_id")

--- a/CineHive/src/main/java/com/example/CineHive/mapper/OttMapper.java
+++ b/CineHive/src/main/java/com/example/CineHive/mapper/OttMapper.java
@@ -1,0 +1,31 @@
+package com.example.CineHive.mapper;
+
+import com.example.CineHive.dto.ott.OttDto;
+import com.example.CineHive.dto.ott.ProviderDto;
+import com.example.CineHive.entity.ott.Ott;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class OttMapper {
+
+    // 엔티티 -> DTO 변환
+    public static OttDto toDto(Ott ott) {
+        return new OttDto(
+                ott.getId(),
+                ott.getTitle(),
+                ott.getOverview(),
+                ott.getPosterPath(),
+                ott.getPopularity(),
+                ott.getReleaseDate(),
+                new ProviderDto(ott.getProvider().getId(), ott.getProvider().getName())
+        );
+    }
+
+    // 엔티티 리스트 -> DTO 리스트 변환
+    public static List<OttDto> toDtoList(List<Ott> movies) {
+        return movies.stream()
+                .map(OttMapper::toDto)
+                .collect(Collectors.toList());
+    }
+}

--- a/CineHive/src/main/java/com/example/CineHive/repository/ott/OttRepository.java
+++ b/CineHive/src/main/java/com/example/CineHive/repository/ott/OttRepository.java
@@ -1,0 +1,13 @@
+package com.example.CineHive.repository.ott;
+
+import com.example.CineHive.entity.ott.Ott;
+import com.example.CineHive.entity.ott.Provider;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface OttRepository extends JpaRepository<Ott, Long> {
+    List<Ott> findByProvider(Provider provider);
+}

--- a/CineHive/src/main/java/com/example/CineHive/repository/ott/ProviderRepository.java
+++ b/CineHive/src/main/java/com/example/CineHive/repository/ott/ProviderRepository.java
@@ -1,0 +1,9 @@
+package com.example.CineHive.repository.ott;
+
+import com.example.CineHive.entity.ott.Provider;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProviderRepository extends JpaRepository<Provider, Integer> {
+}

--- a/CineHive/src/main/java/com/example/CineHive/scheduler/ScheduledTasks.java
+++ b/CineHive/src/main/java/com/example/CineHive/scheduler/ScheduledTasks.java
@@ -1,17 +1,79 @@
 package com.example.CineHive.scheduler;
 
+import com.example.CineHive.service.credit.movie.NowPlayingMovieService;
+import com.example.CineHive.service.credit.movie.PopularMovieService;
+import com.example.CineHive.service.credit.movie.TopRatedMovieService;
+import com.example.CineHive.service.credit.movie.UpComingMovieService;
 import com.example.CineHive.service.ott.OttService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 @Component
 @RequiredArgsConstructor
 public class ScheduledTasks {
     private final OttService ottService;
 
+    private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    @Autowired
+    private UpComingMovieService upComingMovieService;
+
+    @Autowired
+    private TopRatedMovieService topRatedMovieService;
+
+    @Autowired
+    private PopularMovieService popularMovieService;
+
+    @Autowired
+    private NowPlayingMovieService nowPlayingMovieService;
     @Scheduled(cron = "0 0 3 * * ?")
     public void updateMovies() {
         ottService.fetchAndSaveAllPlatformsMovies();
+    }
+
+    //개봉 예정 영화 자동 업데이트
+    @Scheduled(cron = "0 0 3 * * *")
+    @Transactional
+    public void updateUpcomingMoviesDaily() {
+        String currentTime = LocalDateTime.now().format(formatter);
+        System.out.println("[" + currentTime + "] [자동 업데이트] 개봉 예정 영화 업데이트 시작...");
+        upComingMovieService.saveUpComingMoviesToDatabase();
+        System.out.println("[" + currentTime + "] [자동 업데이트]개봉 예정 영화 업데이트 완료!");
+    }
+
+    // 평점 순위 영화 자동 업데이트
+    @Scheduled(cron = "0 0 3 * * *")
+    @Transactional
+    public void updateTopRatedMoviesDaily() {
+        String currentTime = LocalDateTime.now().format(formatter);
+        System.out.println("[" + currentTime + "] [자동 업데이트] 현재 상영 영화 업데이트 시작...");
+        topRatedMovieService.saveTopRatedMoviesToDatabase();
+        System.out.println("[" + currentTime + "] [자동 업데이트] 현재 상영 영화 업데이트 완료!");
+    }
+
+    // 인기 영화 자동 업데이트
+    @Scheduled(cron = "0 0 3 * * *")
+    @Transactional
+    public void updatePopularMoviesDaily() {
+        String currentTime = LocalDateTime.now().format(formatter);
+        System.out.println("[" + currentTime + "] [자동 업데이트] 인기 영화 업데이트 시작...");
+        popularMovieService.savePopularMoviesToDatabase();
+        System.out.println("[" + currentTime + "] [자동 업데이트] 인기 영화 업데이트 완료!");
+    }
+
+    // 현재 상영영화 자동 업데이트 (매일 자정)
+    @Scheduled(cron = "0 0 0 * * *")
+    @Transactional
+    public void updateNowPlayingMoviesDaily() {
+        String currentTime = LocalDateTime.now().format(formatter);
+        System.out.println("[" + currentTime + "] [자동 업데이트] 현재 상영 영화 업데이트 시작...");
+        nowPlayingMovieService.saveNowPlayingMoviesToDatabase();
+        System.out.println("[" + currentTime + "] [자동 업데이트] 현재 상영 영화 업데이트 완료!");
     }
 }

--- a/CineHive/src/main/java/com/example/CineHive/scheduler/ScheduledTasks.java
+++ b/CineHive/src/main/java/com/example/CineHive/scheduler/ScheduledTasks.java
@@ -1,0 +1,17 @@
+package com.example.CineHive.scheduler;
+
+import com.example.CineHive.service.ott.OttService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ScheduledTasks {
+    private final OttService ottService;
+
+    @Scheduled(cron = "0 0 3 * * ?")
+    public void updateMovies() {
+        ottService.fetchAndSaveAllPlatformsMovies();
+    }
+}

--- a/CineHive/src/main/java/com/example/CineHive/scheduler/ScheduledTasks.java
+++ b/CineHive/src/main/java/com/example/CineHive/scheduler/ScheduledTasks.java
@@ -32,13 +32,13 @@ public class ScheduledTasks {
 
     @Autowired
     private NowPlayingMovieService nowPlayingMovieService;
-    @Scheduled(cron = "0 0 3 * * ?")
+    @Scheduled(cron = "0 0 0 * * ?")
     public void updateMovies() {
         ottService.fetchAndSaveAllPlatformsMovies();
     }
 
     //개봉 예정 영화 자동 업데이트
-    @Scheduled(cron = "0 0 3 * * *")
+    @Scheduled(cron = "0 0 0 * * *")
     @Transactional
     public void updateUpcomingMoviesDaily() {
         String currentTime = LocalDateTime.now().format(formatter);
@@ -48,7 +48,7 @@ public class ScheduledTasks {
     }
 
     // 평점 순위 영화 자동 업데이트
-    @Scheduled(cron = "0 0 3 * * *")
+    @Scheduled(cron = "0 0 0 * * *")
     @Transactional
     public void updateTopRatedMoviesDaily() {
         String currentTime = LocalDateTime.now().format(formatter);
@@ -58,7 +58,7 @@ public class ScheduledTasks {
     }
 
     // 인기 영화 자동 업데이트
-    @Scheduled(cron = "0 0 3 * * *")
+    @Scheduled(cron = "0 0 0 * * *")
     @Transactional
     public void updatePopularMoviesDaily() {
         String currentTime = LocalDateTime.now().format(formatter);

--- a/CineHive/src/main/java/com/example/CineHive/scheduler/ScheduledTasks.java
+++ b/CineHive/src/main/java/com/example/CineHive/scheduler/ScheduledTasks.java
@@ -44,7 +44,7 @@ public class ScheduledTasks {
     }
 
     //개봉 예정 영화 자동 업데이트
-    @Scheduled(cron = "0 0 0 * * *")
+    @Scheduled(cron = "0 0 3 * * *")
     @Transactional
     public void updateUpcomingMoviesDaily() {
         String currentTime = LocalDateTime.now().format(formatter);
@@ -54,7 +54,7 @@ public class ScheduledTasks {
     }
 
     // 평점 순위 영화 자동 업데이트
-    @Scheduled(cron = "0 0 0 * * *")
+    @Scheduled(cron = "0 0 1 * * *")
     @Transactional
     public void updateTopRatedMoviesDaily() {
         String currentTime = LocalDateTime.now().format(formatter);
@@ -64,7 +64,7 @@ public class ScheduledTasks {
     }
 
     // 인기 영화 자동 업데이트
-    @Scheduled(cron = "0 0 0 * * *")
+    @Scheduled(cron = "0 0 2 * * *")
     @Transactional
     public void updatePopularMoviesDaily() {
         String currentTime = LocalDateTime.now().format(formatter);
@@ -74,7 +74,7 @@ public class ScheduledTasks {
     }
 
     // 현재 상영영화 자동 업데이트 (매일 자정)
-    @Scheduled(cron = "0 0 0 * * *")
+    @Scheduled(cron = "0 0 4 * * *")
     @Transactional
     public void updateNowPlayingMoviesDaily() {
         String currentTime = LocalDateTime.now().format(formatter);

--- a/CineHive/src/main/java/com/example/CineHive/scheduler/ScheduledTasks.java
+++ b/CineHive/src/main/java/com/example/CineHive/scheduler/ScheduledTasks.java
@@ -1,5 +1,6 @@
 package com.example.CineHive.scheduler;
 
+import com.example.CineHive.repository.ott.OttRepository;
 import com.example.CineHive.service.credit.movie.NowPlayingMovieService;
 import com.example.CineHive.service.credit.movie.PopularMovieService;
 import com.example.CineHive.service.credit.movie.TopRatedMovieService;
@@ -32,9 +33,14 @@ public class ScheduledTasks {
 
     @Autowired
     private NowPlayingMovieService nowPlayingMovieService;
+
+    @Autowired
+    private OttRepository ottRepository;
     @Scheduled(cron = "0 0 0 * * ?")
     public void updateMovies() {
+        ottRepository.deleteAll();
         ottService.fetchAndSaveAllPlatformsMovies();
+
     }
 
     //개봉 예정 영화 자동 업데이트

--- a/CineHive/src/main/java/com/example/CineHive/service/credit/movie/NowPlayingMovieService.java
+++ b/CineHive/src/main/java/com/example/CineHive/service/credit/movie/NowPlayingMovieService.java
@@ -52,17 +52,6 @@ public class NowPlayingMovieService {
         this.objectMapper = objectMapper;
     }
 
-    private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
-
-    // 현재 상영영화 자동저장 (매일 자정)
-    @Scheduled(cron = "0 0 0 * * *")
-    @Transactional
-    public void updateNowPlayingMoviesDaily() {
-        String currentTime = LocalDateTime.now().format(formatter);
-        System.out.println("[" + currentTime + "] [자동 업데이트] 현재 상영 영화 업데이트 시작...");
-        saveNowPlayingMoviesToDatabase();
-        System.out.println("[" + currentTime + "] [자동 업데이트] 현재 상영 영화 업데이트 완료!");
-    }
 
     @Transactional
     public void saveNowPlayingMoviesToDatabase() {

--- a/CineHive/src/main/java/com/example/CineHive/service/credit/movie/PopularMovieService.java
+++ b/CineHive/src/main/java/com/example/CineHive/service/credit/movie/PopularMovieService.java
@@ -57,17 +57,6 @@ public class PopularMovieService {
     }
 
 
-    private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
-
-    @Scheduled(cron = "0 0 3 * * *")
-    @Transactional
-    public void updatePopularMoviesDaily() {
-        String currentTime = LocalDateTime.now().format(formatter);
-        System.out.println("[" + currentTime + "] [자동 업데이트] 인기 영화 업데이트 시작...");
-        savePopularMoviesToDatabase();
-        System.out.println("[" + currentTime + "] [자동 업데이트] 인기 영화 업데이트 완료!");
-    }
-
     @Transactional
     public void savePopularMoviesToDatabase() {
         // API를 호출하여 데이터를 가져옵니다.

--- a/CineHive/src/main/java/com/example/CineHive/service/credit/movie/TopRatedMovieService.java
+++ b/CineHive/src/main/java/com/example/CineHive/service/credit/movie/TopRatedMovieService.java
@@ -46,22 +46,11 @@ public class TopRatedMovieService {
     @Autowired
     private SimilarMovieService similarMovieService;
 
-    private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
-
     public TopRatedMovieService(WebClient.Builder webClientBuilder, ObjectMapper objectMapper) {
         this.webClient = webClientBuilder.baseUrl("https://api.themoviedb.org/3").build();
         this.objectMapper = objectMapper;
     }
 
-    // Top Rated 영화 자동저장 (매일 새벽 3시)
-    @Scheduled(cron = "0 0 3 * * *")
-    @Transactional
-    public void updateTopRatedMoviesDaily() {
-        String currentTime = LocalDateTime.now().format(formatter);
-        System.out.println("[" + currentTime + "] [자동 업데이트] 현재 상영 영화 업데이트 시작...");
-        saveTopRatedMoviesToDatabase();
-        System.out.println("[" + currentTime + "] [자동 업데이트] 현재 상영 영화 업데이트 완료!");
-    }
 
     @Transactional
     public void saveTopRatedMoviesToDatabase() {

--- a/CineHive/src/main/java/com/example/CineHive/service/credit/movie/UpComingMovieService.java
+++ b/CineHive/src/main/java/com/example/CineHive/service/credit/movie/UpComingMovieService.java
@@ -51,16 +51,6 @@ public class UpComingMovieService {
     @Autowired
     private SimilarMovieService similarMovieService;
 
-    private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
-
-    @Scheduled(cron = "0 0 3 * * *")
-    @Transactional
-    public void updateUpcomingMoviesDaily() {
-        String currentTime = LocalDateTime.now().format(formatter);
-        System.out.println("[" + currentTime + "] [자동 업데이트] 개봉 예정 영화 업데이트 시작...");
-        saveUpComingMoviesToDatabase();
-        System.out.println("[" + currentTime + "] [자동 업데이트]개봉 예정 영화 업데이트 완료!");
-    }
 
     @Transactional
     public void saveUpComingMoviesToDatabase() {

--- a/CineHive/src/main/java/com/example/CineHive/service/ott/OttService.java
+++ b/CineHive/src/main/java/com/example/CineHive/service/ott/OttService.java
@@ -43,7 +43,6 @@ public class OttService {
             "disney", 337,
             "watcha", 97,
             "tving", 356,
-            "wavve", 356
     );
 
     @PostConstruct

--- a/CineHive/src/main/java/com/example/CineHive/service/ott/OttService.java
+++ b/CineHive/src/main/java/com/example/CineHive/service/ott/OttService.java
@@ -48,16 +48,20 @@ public class OttService {
     @PostConstruct
     @Transactional
     public void initializeProviders() {
-        System.out.println("🔹 initializeProviders() 실행됨");
-        DEFAULT_PROVIDERS.forEach((name, id) -> {
-            providerRepository.findById(id).orElseGet(() -> {
-                System.out.println("✅ Provider 저장: " + name + " (ID: " + id + ")");
-                Provider provider = new Provider(id, name, null);
-                return providerRepository.save(provider);
+        System.out.println(" initializeProviders() 실행됨");
+        if (providerRepository.count() == 0) {
+            DEFAULT_PROVIDERS.forEach((name, id) -> {
+                providerRepository.findById(id).orElseGet(() -> {
+                    System.out.println(" Provider 저장: " + name + " (ID: " + id + ")");
+                    Provider provider = new Provider(id, name, null);
+                    return providerRepository.save(provider);
+                });
             });
-        });
 
-        fetchAndSaveAllPlatformsMovies();
+            fetchAndSaveAllPlatformsMovies();
+        } else {
+            System.out.println("데이터 존재하므로 초기화 생략");
+        }
     }
     
     public CompletableFuture<List<OttDto>> fetchAndSavePopularMovies(int providerId, String providerName) {

--- a/CineHive/src/main/java/com/example/CineHive/service/ott/OttService.java
+++ b/CineHive/src/main/java/com/example/CineHive/service/ott/OttService.java
@@ -1,0 +1,129 @@
+package com.example.CineHive.service.ott;
+
+import com.example.CineHive.dto.ott.MovieResponseDto;
+import com.example.CineHive.dto.ott.OttDto;
+import com.example.CineHive.entity.ott.Ott;
+import com.example.CineHive.entity.ott.Provider;
+import com.example.CineHive.mapper.OttMapper;
+import com.example.CineHive.repository.ott.OttRepository;
+import com.example.CineHive.repository.ott.ProviderRepository;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class OttService {
+
+    @Autowired
+    private final WebClient.Builder webClientBuilder;
+
+    @Autowired
+    private final OttRepository ottRepository;
+
+    @Autowired
+    private final ProviderRepository providerRepository;
+
+    @Value("${tmdb.api.key}")
+    private String tmdbApiKey;
+    private static final String TMDB_BASE_URL = "https://api.themoviedb.org/3/discover/movie";
+
+
+    private static final Map<String, Integer> DEFAULT_PROVIDERS = Map.of(
+            "netflix", 8,
+            "disney", 337,
+            "watcha", 97,
+            "tving", 356,
+            "wavve", 356
+    );
+
+    @PostConstruct
+    @Transactional
+    public void initializeProviders() {
+        System.out.println("🔹 initializeProviders() 실행됨");
+        DEFAULT_PROVIDERS.forEach((name, id) -> {
+            providerRepository.findById(id).orElseGet(() -> {
+                System.out.println("✅ Provider 저장: " + name + " (ID: " + id + ")");
+                Provider provider = new Provider(id, name, null);
+                return providerRepository.save(provider);
+            });
+        });
+
+        fetchAndSaveAllPlatformsMovies();
+    }
+
+    public int getProviderIdByName(String providerName) {
+        return providerRepository.findAll().stream()
+                .filter(provider -> provider.getName().equalsIgnoreCase(providerName))
+                .map(Provider::getId)
+                .findFirst()
+                .orElse(-1);
+    }
+
+    public CompletableFuture<List<OttDto>> fetchAndSavePopularMovies(int providerId, String providerName) {
+        WebClient webClient = webClientBuilder.baseUrl(TMDB_BASE_URL).build();
+
+        return webClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .queryParam("api_key", tmdbApiKey)
+                        .queryParam("watch_region", "KR")
+                        .queryParam("with_watch_providers", providerId)
+                        .queryParam("sort_by", "popularity.desc")
+                        .build())
+                .retrieve()
+                .bodyToMono(MovieResponseDto.MovieList.class)
+                .map(response -> saveMovies(response.getResults(), providerId, providerName))
+                .map(OttMapper::toDtoList)
+                .toFuture();
+    }
+
+    @Transactional
+    public void fetchAndSaveAllPlatformsMovies() {
+        List<CompletableFuture<List<OttDto>>> futures = DEFAULT_PROVIDERS.entrySet().stream()
+                .map(entry -> {
+                    int providerId = entry.getValue();
+                    String providerName = entry.getKey();
+                    return fetchAndSavePopularMovies(providerId, providerName);
+                })
+                .collect(Collectors.toList());
+
+        // 비동기 작업
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+    }
+
+    // TMDB에서 가져온 데이터를 DB에 저장
+    private List<Ott> saveMovies(List<MovieResponseDto> movies, int providerId, String providerName) {
+        Provider provider = providerRepository.findById(providerId)
+                .orElseThrow(() -> new IllegalArgumentException("Provider not found: " + providerId));
+
+        List<Ott> movieEntities = movies.stream()
+                .map(dto -> new Ott(
+                        null,
+                        dto.getTitle(),
+                        dto.getOverview(),
+                        dto.getPosterPath(),
+                        dto.getPopularity(),
+                        dto.getReleaseDate(),
+                        provider
+                ))
+                .collect(Collectors.toList());
+
+        return ottRepository.saveAll(movieEntities);
+    }
+
+    // 특정 OTT의 인기 영화 조회 (DB에서 가져옴)
+    public List<OttDto> getMoviesByProvider(int providerId) {
+        Provider provider = providerRepository.findById(providerId)
+                .orElseThrow(() -> new IllegalArgumentException("Provider not found: " + providerId));
+        return OttMapper.toDtoList(ottRepository.findByProvider(provider));
+    }
+}

--- a/CineHive/src/main/java/com/example/CineHive/service/ott/OttService.java
+++ b/CineHive/src/main/java/com/example/CineHive/service/ott/OttService.java
@@ -42,7 +42,7 @@ public class OttService {
             "netflix", 8,
             "disney", 337,
             "watcha", 97,
-            "tving", 356,
+            "tving", 356
     );
 
     @PostConstruct
@@ -59,15 +59,7 @@ public class OttService {
 
         fetchAndSaveAllPlatformsMovies();
     }
-
-    public int getProviderIdByName(String providerName) {
-        return providerRepository.findAll().stream()
-                .filter(provider -> provider.getName().equalsIgnoreCase(providerName))
-                .map(Provider::getId)
-                .findFirst()
-                .orElse(-1);
-    }
-
+    
     public CompletableFuture<List<OttDto>> fetchAndSavePopularMovies(int providerId, String providerName) {
         WebClient webClient = webClientBuilder.baseUrl(TMDB_BASE_URL).build();
 

--- a/CineHive/src/main/java/com/example/CineHive/util/JwtTokenUtil.java
+++ b/CineHive/src/main/java/com/example/CineHive/util/JwtTokenUtil.java
@@ -1,12 +1,12 @@
 package com.example.CineHive.util;
 
-/*
-    // HTTP 요청에서 JWT 토큰을 추출하는 메서드
- */
-
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+
+/*
+ HTTP 요청에서 JWT 토큰을 추출하는 메서드
+*/
 
 @Component
 public class JwtTokenUtil {
@@ -19,7 +19,7 @@ public class JwtTokenUtil {
     public String extractTokenFromRequest(HttpServletRequest request) {
         String authorizationHeader = request.getHeader("Authorization");
         if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
-            return authorizationHeader.substring(7); // "Bearer " 이후의 토z큰 부분 추출
+            return authorizationHeader.substring(7);
         }
         return null;
     }


### PR DESCRIPTION
## 작업한 내용
- OTT 플랫폼에 대해 각 인기 콘텐츠 정보 제공 기능 구현
## PR Point
- netflix, tving, watcha, disney+ 4개의 플랫폼에 대해서 각 플랫폼에 대한 인기 콘텐츠 정보를 제공하도록 하는 기능 구현
- 기능은 애플리케이션 실행 시, 자동으로 데이터베이스에 저장이 되며, `/api/ott/{providerId}` 엔드포인트를 통해 클라이언트에서 구현 가능
- 해당 데이터는 `매일 정각에 자동으로 갱신`
- `providerId`는 클라이언트에서 명시적으로 설정을 해줘야 4개의 netflix, tving, watcha, disney+ 플랫폼에 대한 대한 인기 콘텐츠 정보를 불러올 수 있음

### providerId 목록
| providerId       | 플랫폼|
|------------|--------|
| 8 | netflix|
| 337  | disney+  |
| 97  | watcha |
| 356 | tving |

- 상세 페이지 조회 시 해당하는 영화 및 드라마, 애니메이션에 대해 제공하는 플랫폼 기능은 JustWatch API를 이용하여 TMDB API와 연계해서 구현이 가능하지만, 현재 서비스 레이어 구조가 무거워서 구조 개선을 하거나 이후에 기능 확장하는게 낫다고 생각하여 보류하였음.

## 스크린샷
N/A
