### PR TITLE
[feature/mypage] : 마이페이지 로직 구현

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="FrameworkDetectionExcludesConfiguration">

--- a/CineHive/src/main/java/com/example/CineHive/config/SecurityConfig.java
+++ b/CineHive/src/main/java/com/example/CineHive/config/SecurityConfig.java
@@ -1,13 +1,15 @@
 package com.example.CineHive.config;
 
-import com.example.CineHive.filter.JwtRequestFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import com.example.CineHive.filter.JwtRequestFilter;
 
 
 @Configuration
@@ -25,6 +27,8 @@ public class SecurityConfig {
                                 "/top_movie","/movies/**",
                                 "/api/auth/undefined/success",
                                 "/dramas/**",
+                                "/myPage/bookmarks/**",
+                                "/myPage/**",
                                 "/animations/**",
                                 "/get_topmovies",
                                 "/topmovies/**", "/now_playing_movies"
@@ -33,7 +37,7 @@ public class SecurityConfig {
                                 "/swagger-ui.html",
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**",
-                                 "/checkuserId/**").permitAll()
+                                "/checkuserId/**").permitAll()
                                        
                         .requestMatchers("/login", "/register","/checknickname/**","/checkemail/**"
                                 ,"/preferredGenres","/boards/**","/boards"

--- a/CineHive/src/main/java/com/example/CineHive/config/SecurityConfig.java
+++ b/CineHive/src/main/java/com/example/CineHive/config/SecurityConfig.java
@@ -1,8 +1,6 @@
 package com.example.CineHive.config;
 
 import com.example.CineHive.filter.JwtRequestFilter;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -10,11 +8,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.web.cors.CorsConfiguration;
-import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
-import org.springframework.web.filter.CorsFilter;
 
-import java.util.Arrays;
 
 @Configuration
 @EnableWebSecurity

--- a/CineHive/src/main/java/com/example/CineHive/config/SecurityConfig.java
+++ b/CineHive/src/main/java/com/example/CineHive/config/SecurityConfig.java
@@ -28,6 +28,7 @@ public class SecurityConfig {
                                 "/api/auth/undefined/success",
                                 "/dramas/**",
                                 "/myPage/bookmarks/**",
+                                "/myInfo/**",
                                 "/myPage/**",
                                 "/animations/**",
                                 "/get_topmovies",

--- a/CineHive/src/main/java/com/example/CineHive/config/WebConfig.java
+++ b/CineHive/src/main/java/com/example/CineHive/config/WebConfig.java
@@ -1,6 +1,5 @@
 package com.example.CineHive.config;
 
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;

--- a/CineHive/src/main/java/com/example/CineHive/controller/PreferredGenreController.java
+++ b/CineHive/src/main/java/com/example/CineHive/controller/PreferredGenreController.java
@@ -12,7 +12,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;

--- a/CineHive/src/main/java/com/example/CineHive/controller/exception/GlobalExceptionHandler.java
+++ b/CineHive/src/main/java/com/example/CineHive/controller/exception/GlobalExceptionHandler.java
@@ -4,7 +4,6 @@ import com.example.CineHive.exception.TokenExpiredException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 // @RestControllerAdvice
 public class GlobalExceptionHandler {

--- a/CineHive/src/main/java/com/example/CineHive/controller/movie/MovieController.java
+++ b/CineHive/src/main/java/com/example/CineHive/controller/movie/MovieController.java
@@ -1,28 +1,15 @@
 package com.example.CineHive.controller.movie;
 
-import com.example.CineHive.dto.video.movie.NowPlayingMovieDto;
-import com.example.CineHive.dto.video.movie.TopRatedMovieDto;
-import com.example.CineHive.entity.videotype.Animation;
-import com.example.CineHive.entity.videotype.Drama;
 import com.example.CineHive.entity.videotype.Movie;
 import com.example.CineHive.repository.videos.movie.MovieRepository;
-import com.example.CineHive.service.credit.animation.AnimationService;
-import com.example.CineHive.service.credit.drama.DramaService;
-import com.example.CineHive.service.credit.movie.MovieService;
-import com.example.CineHive.service.credit.movie.NowPlayingMovieService;
 import com.example.CineHive.service.credit.movie.SimilarMovieService;
-import com.example.CineHive.service.credit.movie.TopRatedMovieService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 @RestController

--- a/CineHive/src/main/java/com/example/CineHive/controller/movie/NowPlayingMovieController.java
+++ b/CineHive/src/main/java/com/example/CineHive/controller/movie/NowPlayingMovieController.java
@@ -1,7 +1,6 @@
 package com.example.CineHive.controller.movie;
 
 import com.example.CineHive.dto.video.movie.NowPlayingMovieDto;
-import com.example.CineHive.service.credit.movie.MovieService;
 import com.example.CineHive.service.credit.movie.NowPlayingMovieService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;

--- a/CineHive/src/main/java/com/example/CineHive/controller/movie/TopMovieController.java
+++ b/CineHive/src/main/java/com/example/CineHive/controller/movie/TopMovieController.java
@@ -1,7 +1,6 @@
 package com.example.CineHive.controller.movie;
 
 import com.example.CineHive.dto.video.movie.TopRatedMovieDto;
-import com.example.CineHive.service.credit.movie.MovieService;
 import com.example.CineHive.service.credit.movie.TopRatedMovieService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;

--- a/CineHive/src/main/java/com/example/CineHive/controller/myPage/MyInfoController.java
+++ b/CineHive/src/main/java/com/example/CineHive/controller/myPage/MyInfoController.java
@@ -3,15 +3,26 @@ package com.example.CineHive.controller.myPage;
 import com.example.CineHive.dto.user.ChangeMemNameRequest;
 import com.example.CineHive.dto.user.ChangeMemSexRequest;
 import com.example.CineHive.dto.user.ChangePasswordRequest;
+import com.example.CineHive.entity.board.BoardDisLike;
+import com.example.CineHive.repository.UserRepository;
+import com.example.CineHive.repository.board.*;
+import com.example.CineHive.repository.reply.ReplyBookmarkRepository;
+import com.example.CineHive.repository.reply.ReplyDisLikeRepository;
+import com.example.CineHive.repository.reply.ReplyLikeRepository;
+import com.example.CineHive.repository.reply.ReplyRepository;
 import com.example.CineHive.service.UserService;
 import com.example.CineHive.util.JwtTokenUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.Collections;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/myInfo")
@@ -21,6 +32,16 @@ public class MyInfoController {
 
     private final JwtTokenUtil jwtTokenUtil;
     private final UserService userService;
+    private final UserRepository userRepository;
+    private final ReplyLikeRepository replyLikeRepository;
+    private final ReplyDisLikeRepository replyDislikeRepository;
+    private final BookmarkRepository bookmarkRepository;
+    private final DisLikeRepository disLikeRepository;
+    private final LikeRepository likeRepository;
+    private final ReplyRepository replyRepository;
+    private final CommentRepository commentRepository;
+    private final BoardRepository boardRepository;
+    private final ReplyBookmarkRepository replyBookmarkRepository;
 
     @PutMapping("/change-password")
     @Operation(summary = "비밀번호 변경", description = "기존 비밀번호 확인 후 새 비밀번호로 변경")
@@ -43,6 +64,23 @@ public class MyInfoController {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("비밀번호 변경 중 오류 발생");
         }
     }
+
+    @PostMapping("/check-password")
+    @Operation(summary = "비밀번호 확인", description = "비밀번호가 맞는지 검증")
+    public ResponseEntity<?> checkPassword(@RequestBody Map<String, String> request, HttpServletRequest servletRequest) {
+        String token = jwtTokenUtil.extractTokenFromRequest(servletRequest);
+        if (token == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("토큰이 필요합니다.");
+        }
+
+        String password = request.get("password");
+        String email = jwtTokenUtil.extractUsername(token);
+
+        boolean isMatch = userService.checkPassword(email, password);
+
+        return ResponseEntity.ok(Collections.singletonMap("success", isMatch));
+    }
+
 
 
     @PutMapping("/change-memname")
@@ -89,4 +127,55 @@ public class MyInfoController {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("성별 변경 중 오류 발생");
         }
     }
+
+    @DeleteMapping("/delete-account")
+    @Operation(summary = "회원 탈퇴", description = "JWT를 통해 인증된 사용자가 작성한 모든 데이터와 계정을 삭제합니다.")
+    @Transactional
+    public ResponseEntity<?> deleteAccount(HttpServletRequest request) {
+        String token = jwtTokenUtil.extractTokenFromRequest(request);
+        if (token == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("토큰이 필요합니다.");
+        }
+
+        try {
+            String memEmail = jwtTokenUtil.extractUsername(token);
+
+            // 1. 감상평 좋아요 삭제
+            replyLikeRepository.deleteByMemEmail(memEmail);
+
+            // 2. 감상평 싫어요 삭제
+            replyDislikeRepository.deleteByMemEmail(memEmail);
+
+            // 3.찜 삭제
+            bookmarkRepository.deleteByUser_MemEmail(memEmail);
+            replyBookmarkRepository.deleteByMemEmail(memEmail);
+
+            // 4. 게시글 좋아요 삭제
+            likeRepository.deleteByUser_MemEmail(memEmail);
+
+            // 5. 게시글 싫어요 삭제
+            disLikeRepository.deleteByUser_MemEmail(memEmail);
+
+            // 6. 댓글 삭제
+            commentRepository.deleteByUser_MemEmail(memEmail);
+
+            // 7. 감상평 삭제
+            replyRepository.deleteByMemEmail(memEmail);
+
+            // 8. 게시글 삭제
+            boardRepository.deleteByUserMemEmail(memEmail);
+
+            // 9. 유저 삭제
+            userRepository.deleteByMemEmail(memEmail);
+
+            return ResponseEntity.ok("회원 탈퇴 완료");
+        } catch (Exception e) {
+            e.printStackTrace();
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("회원 탈퇴 실패");
+        }
+    }
+
+
+
+
 }

--- a/CineHive/src/main/java/com/example/CineHive/controller/myPage/MyInfoController.java
+++ b/CineHive/src/main/java/com/example/CineHive/controller/myPage/MyInfoController.java
@@ -1,0 +1,92 @@
+package com.example.CineHive.controller.myPage;
+
+import com.example.CineHive.dto.user.ChangeMemNameRequest;
+import com.example.CineHive.dto.user.ChangeMemSexRequest;
+import com.example.CineHive.dto.user.ChangePasswordRequest;
+import com.example.CineHive.service.UserService;
+import com.example.CineHive.util.JwtTokenUtil;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/myInfo")
+@RequiredArgsConstructor
+@Tag(name = "MyInfo Controller", description = "사용자 정보 관련 기능을 제공하는 API")
+public class MyInfoController {
+
+    private final JwtTokenUtil jwtTokenUtil;
+    private final UserService userService;
+
+    @PutMapping("/change-password")
+    @Operation(summary = "비밀번호 변경", description = "기존 비밀번호 확인 후 새 비밀번호로 변경")
+    public ResponseEntity<?> changePassword(@RequestBody ChangePasswordRequest request, HttpServletRequest httpRequest) {
+        String token = jwtTokenUtil.extractTokenFromRequest(httpRequest);
+        if (token == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("토큰이 필요합니다.");
+        }
+
+        try {
+            String email = jwtTokenUtil.extractUsername(token);
+            boolean result = userService.changePassword(email, request.getOldPassword(), request.getNewPassword());
+            if (result) {
+                return ResponseEntity.ok("비밀번호가 성공적으로 변경되었습니다.");
+            } else {
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("기존 비밀번호가 일치하지 않습니다.");
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("비밀번호 변경 중 오류 발생");
+        }
+    }
+
+
+    @PutMapping("/change-memname")
+    @Operation(summary = "이름 변경", description = "사용자가 입력한 이름으로 변경")
+    public ResponseEntity<?> changeMemName(@RequestBody ChangeMemNameRequest request, HttpServletRequest httpRequest) {
+        String token = jwtTokenUtil.extractTokenFromRequest(httpRequest);
+        if (token == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("토큰이 필요합니다.");
+        }
+
+        try {
+            String email = jwtTokenUtil.extractUsername(token);
+            boolean result = userService.changeMemName(email, request.getNewMemName());
+            if (result) {
+                return ResponseEntity.ok("이름이 성공적으로 변경되었습니다.");
+            } else {
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("이름 변경 실패");
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("이름 변경 중 오류 발생");
+        }
+    }
+
+
+    @PutMapping("/change-memsex")
+    @Operation(summary = "성별 변경", description = "사용자가 입력한 성별로 변경 (male, female, other만 허용)")
+    public ResponseEntity<?> changeMemSex(@RequestBody ChangeMemSexRequest request, HttpServletRequest httpRequest) {
+        String token = jwtTokenUtil.extractTokenFromRequest(httpRequest);
+        if (token == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("토큰이 필요합니다.");
+        }
+
+        try {
+            String email = jwtTokenUtil.extractUsername(token);
+            boolean result = userService.changeMemSex(email, request.getNewMemSex());
+            if (result) {
+                return ResponseEntity.ok("성별이 성공적으로 변경되었습니다.");
+            } else {
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("유효한 성별 값은 male, female, other 입니다.");
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("성별 변경 중 오류 발생");
+        }
+    }
+}

--- a/CineHive/src/main/java/com/example/CineHive/controller/myPage/MyPageController.java
+++ b/CineHive/src/main/java/com/example/CineHive/controller/myPage/MyPageController.java
@@ -8,6 +8,7 @@ import com.example.CineHive.dto.user.ChangeMemSexRequest;
 import com.example.CineHive.dto.user.ChangePasswordRequest;
 import com.example.CineHive.entity.User;
 import com.example.CineHive.entity.board.Board;
+import com.example.CineHive.entity.board.BoardLike;
 import com.example.CineHive.entity.board.Comment;
 
 import com.example.CineHive.entity.reply.Reply;
@@ -17,6 +18,7 @@ import com.example.CineHive.repository.LoginHistoryRepository;
 import com.example.CineHive.repository.UserRepository;
 import com.example.CineHive.repository.board.BoardRepository;
 import com.example.CineHive.repository.board.CommentRepository;
+import com.example.CineHive.repository.board.LikeRepository;
 import com.example.CineHive.repository.reply.ReplyRepository;
 import com.example.CineHive.repository.videos.movie.MovieRepository;
 import com.example.CineHive.service.UserService;
@@ -32,7 +34,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -50,7 +54,7 @@ public class MyPageController {
     private final UserService userService;
     private final UserRepository userRepository;
     private final CommentRepository commentRepository;
-    private CommentMapper commentMapper;
+    private final LikeRepository likeRepository;
 
     @GetMapping("/info")
     @Operation(summary = "내 정보 조회", description = "JWT를 통해 인증된 사용자의 기본 정보를 조회합니다.")
@@ -134,8 +138,8 @@ public class MyPageController {
         }
     }
 
-    @GetMapping("/likes")
-    @Operation(summary = "내가 좋아요한 댓글 조회", description = "JWT에서 추출한 사용자 email을 기준으로 좋아요한 댓글 정보를 조회")
+    @GetMapping("/boardlikes")
+    @Operation(summary = "내가 좋아요한 게시글 조회", description = "사용자가 좋아요한 게시글 정보를 조회")
     public ResponseEntity<?> getMyLikes(HttpServletRequest request) {
         String token = jwtTokenUtil.extractTokenFromRequest(request);
         if (token == null) {
@@ -144,11 +148,29 @@ public class MyPageController {
 
         try {
             String memEmail = jwtTokenUtil.extractUsername(token);
-            System.out.println("토큰에서 추출한 이메일: " + memEmail);
+            Optional<User> optionalUser = userRepository.findByMemEmail(memEmail);
 
-            List<Reply> myLikes = replyRepository.findByMemEmail(memEmail);
+            if (optionalUser.isEmpty()) {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND).body("사용자를 찾을 수 없습니다.");
+            }
 
-            return ResponseEntity.ok(myLikes);
+            User user = optionalUser.get();
+
+            List<BoardLike> myLikes = likeRepository.findByUser(user);
+
+            List<Map<String, Object>> likedBoards = myLikes.stream()
+                    .map(boardLike -> {
+                        Map<String, Object> map = new HashMap<>();
+                        map.put("boardId", boardLike.getBoard().getId());
+                        map.put("boardTitle", boardLike.getBoard().getBrdTitle());
+                        map.put("boardContent", boardLike.getBoard().getBrdContent());
+                        map.put("boardViews", boardLike.getBoard().getViews());
+                        map.put("boardRegDate", boardLike.getBoard().getBrdRegDate());
+                        return map;
+                    })
+                    .collect(Collectors.toList());
+
+            return ResponseEntity.ok(likedBoards);
         } catch (Exception e) {
             e.printStackTrace();
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("유효하지 않은 토큰입니다.");

--- a/CineHive/src/main/java/com/example/CineHive/controller/myPage/MyPageController.java
+++ b/CineHive/src/main/java/com/example/CineHive/controller/myPage/MyPageController.java
@@ -2,6 +2,7 @@ package com.example.CineHive.controller.myPage;
 
 import com.example.CineHive.dto.board.GetListBoardDto;
 import com.example.CineHive.dto.user.ChangeMemNameRequest;
+import com.example.CineHive.dto.user.ChangeMemSexRequest;
 import com.example.CineHive.dto.user.ChangePasswordRequest;
 import com.example.CineHive.entity.board.Board;
 import com.example.CineHive.entity.videotype.Movie;
@@ -120,6 +121,28 @@ public class MyPageController {
         } catch (Exception e) {
             e.printStackTrace();
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("이름 변경 중 오류 발생");
+        }
+    }
+
+    @PutMapping("/change-memsex")
+    @Operation(summary = "성별 변경", description = "사용자가 입력한 성별로 변경 (male, female, other만 허용)")
+    public ResponseEntity<?> changeMemSex(@RequestBody ChangeMemSexRequest request, HttpServletRequest httpRequest) {
+        String token = jwtTokenUtil.extractTokenFromRequest(httpRequest);
+        if (token == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("토큰이 필요합니다.");
+        }
+
+        try {
+            String email = jwtTokenUtil.extractUsername(token);
+            boolean result = userService.changeMemSex(email, request.getNewMemSex());
+            if (result) {
+                return ResponseEntity.ok("성별이 성공적으로 변경되었습니다.");
+            } else {
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("유효한 성별 값은 male, female, other 입니다.");
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("성별 변경 중 오류 발생");
         }
     }
 

--- a/CineHive/src/main/java/com/example/CineHive/controller/myPage/MyPageController.java
+++ b/CineHive/src/main/java/com/example/CineHive/controller/myPage/MyPageController.java
@@ -1,13 +1,19 @@
 package com.example.CineHive.controller.myPage;
 
 import com.example.CineHive.dto.board.GetListBoardDto;
+import com.example.CineHive.dto.comment.CommentDto;
 import com.example.CineHive.dto.user.ChangeMemNameRequest;
 import com.example.CineHive.dto.user.ChangeMemSexRequest;
 import com.example.CineHive.dto.user.ChangePasswordRequest;
+import com.example.CineHive.entity.User;
 import com.example.CineHive.entity.board.Board;
+import com.example.CineHive.entity.board.Comment;
+
 import com.example.CineHive.entity.videotype.Movie;
 import com.example.CineHive.repository.LoginHistoryRepository;
+import com.example.CineHive.repository.UserRepository;
 import com.example.CineHive.repository.board.BoardRepository;
+import com.example.CineHive.repository.board.CommentRepository;
 import com.example.CineHive.repository.videos.movie.MovieRepository;
 import com.example.CineHive.service.UserService;
 import com.example.CineHive.service.board.BoardService;
@@ -22,7 +28,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
-
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 
 @RestController
@@ -36,6 +43,8 @@ public class MyPageController {
     private final BoardRepository boardRepository;
     private final BoardService boardService;
     private final UserService userService;
+    private final UserRepository userRepository;
+    private final CommentRepository commentRepository;
 
     @GetMapping("/bookmarks")
     @Operation(summary = "찜한 영화 목록 조회", description = "JWT에서 추출한 사용자 email을 기준으로 찜한 영화 정보를 조회")
@@ -61,24 +70,51 @@ public class MyPageController {
         }
     }
 
-//    @GetMapping("/boards")
-//    @Operation(summary = "사용자가 작성한 게시글 목록 조회", description = "JWT에서 추출한 사용자 email을 기준으로 본인이 작성한 게시글 목록을 조회합니다.")
-//    public ResponseEntity<?> getUserBoards(HttpServletRequest request) {
-//        String token = jwtTokenUtil.extractTokenFromRequest(request);
-//        if (token == null) {
-//            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("토큰이 필요합니다.");
-//        }
-//
-//        try {
-//            String memEmail = jwtTokenUtil.extractUsername(token);
-//            List<Board> boards = boardService.getBoardsByMemEmail(memEmail);
-//
-//            return ResponseEntity.ok(boards);
-//        } catch (Exception e) {
-//            e.printStackTrace();
-//            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("유효하지 않은 토큰입니다.");
-//        }
-//    }
+
+
+    @GetMapping("/comments")
+    @Operation(summary = "작성한 댓글 조회", description = "JWT를 통해 인증된 사용자의 댓글 목록을 조회합니다.")
+    public ResponseEntity<?> getMyComments(HttpServletRequest request) {
+        String token = jwtTokenUtil.extractTokenFromRequest(request);
+
+        if (token == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("토큰이 필요합니다.");
+        }
+
+        try {
+            String memEmail = jwtTokenUtil.extractUsername(token);
+            Optional<User> optionalUser = userRepository.findByMemEmail(memEmail);
+
+            if (optionalUser.isEmpty()) {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND).body("사용자를 찾을 수 없습니다.");
+            }
+
+            User user = optionalUser.get();
+            Long memId = user.getMem_id();
+
+            // ✅ memId로 댓글 전체 조회
+            List<Comment> comments = commentRepository.findCommentsByUserId(memId);
+
+            // DTO로 변환
+            List<CommentDto> commentDtos = comments.stream()
+                    .map(comment -> new CommentDto(
+                            comment.getId(),
+                            comment.getContent(),
+                            comment.getUser().getMemNickname(),
+                            comment.getUser().getMemEmail(),
+                            comment.getCreatedAt()
+                    ))
+                    .collect(Collectors.toList());
+
+            return ResponseEntity.ok(commentDtos);
+        } catch (Exception e) {
+            e.printStackTrace();
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("유효하지 않은 토큰입니다.");
+        }
+    }
+
+
+
 
     @PutMapping("/change-password")
     @Operation(summary = "비밀번호 변경", description = "기존 비밀번호 확인 후 새 비밀번호로 변경")
@@ -145,7 +181,4 @@ public class MyPageController {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("성별 변경 중 오류 발생");
         }
     }
-
-
-
 }

--- a/CineHive/src/main/java/com/example/CineHive/controller/myPage/MyPageController.java
+++ b/CineHive/src/main/java/com/example/CineHive/controller/myPage/MyPageController.java
@@ -8,6 +8,7 @@ import com.example.CineHive.dto.user.ChangeMemSexRequest;
 import com.example.CineHive.dto.user.ChangePasswordRequest;
 import com.example.CineHive.entity.User;
 import com.example.CineHive.entity.board.Board;
+import com.example.CineHive.entity.board.BoardDisLike;
 import com.example.CineHive.entity.board.BoardLike;
 import com.example.CineHive.entity.board.Comment;
 
@@ -18,6 +19,7 @@ import com.example.CineHive.repository.LoginHistoryRepository;
 import com.example.CineHive.repository.UserRepository;
 import com.example.CineHive.repository.board.BoardRepository;
 import com.example.CineHive.repository.board.CommentRepository;
+import com.example.CineHive.repository.board.DisLikeRepository;
 import com.example.CineHive.repository.board.LikeRepository;
 import com.example.CineHive.repository.reply.ReplyRepository;
 import com.example.CineHive.repository.videos.movie.MovieRepository;
@@ -55,6 +57,7 @@ public class MyPageController {
     private final UserRepository userRepository;
     private final CommentRepository commentRepository;
     private final LikeRepository likeRepository;
+    private final DisLikeRepository dislikeRepository;
 
     @GetMapping("/info")
     @Operation(summary = "내 정보 조회", description = "JWT를 통해 인증된 사용자의 기본 정보를 조회합니다.")
@@ -171,6 +174,44 @@ public class MyPageController {
                     .collect(Collectors.toList());
 
             return ResponseEntity.ok(likedBoards);
+        } catch (Exception e) {
+            e.printStackTrace();
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("유효하지 않은 토큰입니다.");
+        }
+    }
+
+    @GetMapping("/boarddislikes")
+    @Operation(summary = "내가 싫어요한 게시글 조회", description = "사용자가 싫어요한 게시글 정보를 조회")
+    public ResponseEntity<?> getMydisLikes(HttpServletRequest request) {
+        String token = jwtTokenUtil.extractTokenFromRequest(request);
+        if (token == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("토큰이 필요합니다.");
+        }
+
+        try {
+            String memEmail = jwtTokenUtil.extractUsername(token);
+            Optional<User> optionalUser = userRepository.findByMemEmail(memEmail);
+
+            if (optionalUser.isEmpty()) {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND).body("사용자를 찾을 수 없습니다.");
+            }
+
+            User user = optionalUser.get();
+            List<BoardDisLike> mydislikes  = dislikeRepository.findByUser(user);
+
+            List<Map<String, Object>> dislikedBoards = mydislikes .stream()
+                    .map(boardLike -> {
+                        Map<String, Object> map = new HashMap<>();
+                        map.put("boardId", boardLike.getBoard().getId());
+                        map.put("boardTitle", boardLike.getBoard().getBrdTitle());
+                        map.put("boardContent", boardLike.getBoard().getBrdContent());
+                        map.put("boardViews", boardLike.getBoard().getViews());
+                        map.put("boardRegDate", boardLike.getBoard().getBrdRegDate());
+                        return map;
+                    })
+                    .collect(Collectors.toList());
+
+            return ResponseEntity.ok(dislikedBoards);
         } catch (Exception e) {
             e.printStackTrace();
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("유효하지 않은 토큰입니다.");

--- a/CineHive/src/main/java/com/example/CineHive/controller/myPage/MyPageController.java
+++ b/CineHive/src/main/java/com/example/CineHive/controller/myPage/MyPageController.java
@@ -12,6 +12,7 @@ import com.example.CineHive.entity.board.Comment;
 
 import com.example.CineHive.entity.reply.Reply;
 import com.example.CineHive.entity.videotype.Movie;
+import com.example.CineHive.mapper.CommentMapper;
 import com.example.CineHive.repository.LoginHistoryRepository;
 import com.example.CineHive.repository.UserRepository;
 import com.example.CineHive.repository.board.BoardRepository;
@@ -26,6 +27,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -48,6 +50,44 @@ public class MyPageController {
     private final UserService userService;
     private final UserRepository userRepository;
     private final CommentRepository commentRepository;
+    private CommentMapper commentMapper;
+
+    @GetMapping("/info")
+    @Operation(summary = "내 정보 조회", description = "JWT를 통해 인증된 사용자의 기본 정보를 조회합니다.")
+    public ResponseEntity<?> getMyInfo(HttpServletRequest request) {
+        String token = jwtTokenUtil.extractTokenFromRequest(request);
+        if (token == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("토큰이 필요합니다.");
+        }
+
+        try {
+            String memEmail = jwtTokenUtil.extractUsername(token);
+            Optional<User> optionalUser = userRepository.findByMemEmail(memEmail);
+
+            if (optionalUser.isEmpty()) {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND).body("사용자를 찾을 수 없습니다.");
+            }
+
+            User user = optionalUser.get();
+
+            // 필요한 정보만 추려서 반환
+            return ResponseEntity.ok(
+                    new java.util.HashMap<String, Object>() {{
+                        put("memName", user.getMemName());
+                        put("memEmail", user.getMemEmail());
+                        put("memNickname", user.getMemNickname());
+                        put("memSex", user.getMemSex());
+                        put("genres", user.getGenres());
+                    }}
+            );
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("사용자 정보 조회 실패");
+        }
+    }
+
+
 
     @GetMapping("/bookmarks")
     @Operation(summary = "찜한 영화 목록 조회", description = "JWT에서 추출한 사용자 email을 기준으로 찜한 영화 정보를 조회")
@@ -144,7 +184,8 @@ public class MyPageController {
                                 comment.getContent(),
                                 comment.getUser().getMemNickname(),
                                 comment.getUser().getMemEmail(),
-                                comment.getCreatedAt()
+                                comment.getCreatedAt(),
+                                comment.getBoard().getId()   // ✅ boardId 추가
                         ))
                         .collect(Collectors.toList());
 
@@ -171,6 +212,7 @@ public class MyPageController {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("유효하지 않은 토큰입니다.");
         }
     }
+
 
 
     @GetMapping("/comments")
@@ -200,11 +242,13 @@ public class MyPageController {
                     .map(comment -> new CommentDto(
                             comment.getId(),
                             comment.getContent(),
-                            comment.getUser().getMemNickname(),
-                            comment.getUser().getMemEmail(),
-                            comment.getCreatedAt()
+                            comment.getUser() != null ? comment.getUser().getMemNickname() : null,
+                            comment.getUser() != null ? comment.getUser().getMemEmail() : null,
+                            comment.getCreatedAt(),
+                            comment.getBoard() != null ? comment.getBoard().getId() : null
                     ))
                     .collect(Collectors.toList());
+
 
             return ResponseEntity.ok(commentDtos);
         } catch (Exception e) {
@@ -212,6 +256,8 @@ public class MyPageController {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("유효하지 않은 토큰입니다.");
         }
     }
+
+
 
 
     @PutMapping("/change-password")

--- a/CineHive/src/main/java/com/example/CineHive/controller/myPage/MyPageController.java
+++ b/CineHive/src/main/java/com/example/CineHive/controller/myPage/MyPageController.java
@@ -10,11 +10,13 @@ import com.example.CineHive.entity.User;
 import com.example.CineHive.entity.board.Board;
 import com.example.CineHive.entity.board.Comment;
 
+import com.example.CineHive.entity.reply.Reply;
 import com.example.CineHive.entity.videotype.Movie;
 import com.example.CineHive.repository.LoginHistoryRepository;
 import com.example.CineHive.repository.UserRepository;
 import com.example.CineHive.repository.board.BoardRepository;
 import com.example.CineHive.repository.board.CommentRepository;
+import com.example.CineHive.repository.reply.ReplyRepository;
 import com.example.CineHive.repository.videos.movie.MovieRepository;
 import com.example.CineHive.service.UserService;
 import com.example.CineHive.service.board.BoardService;
@@ -42,7 +44,7 @@ public class MyPageController {
     private final ReplyBookmarkService replyBookmarkService;
     private final MovieRepository movieRepository;
     private final BoardRepository boardRepository;
-    private final BoardService boardService;
+    private final ReplyRepository replyRepository;
     private final UserService userService;
     private final UserRepository userRepository;
     private final CommentRepository commentRepository;
@@ -59,10 +61,9 @@ public class MyPageController {
         try {
             String memEmail = jwtTokenUtil.extractUsername(token);
             System.out.println("토큰에서 추출한 이메일: " + memEmail);
-            // Step 1: 찜한 movieId 리스트 가져오기
+
             List<Long> movieIds = replyBookmarkService.getBookmarkedMovieIdsByEmail(memEmail);
 
-            // Step 2: movieId들로 Movie 객체 조회
             List<Movie> favoriteMovies = movieRepository.findAllById(movieIds);
             return ResponseEntity.ok(favoriteMovies);
         } catch (Exception e) {
@@ -71,9 +72,51 @@ public class MyPageController {
         }
     }
 
+
+    @GetMapping("/replies")
+    @Operation(summary = "내가 작성한 댓글 조회", description = "JWT에서 추출한 사용자 email을 기준으로 댓글 정보를 조회")
+    public ResponseEntity<?> getMyReplies(HttpServletRequest request) {
+        String token = jwtTokenUtil.extractTokenFromRequest(request);
+        if (token == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("토큰이 필요합니다.");
+        }
+
+        try {
+            String memEmail = jwtTokenUtil.extractUsername(token);
+            System.out.println("토큰에서 추출한 이메일: " + memEmail);
+
+            List<Reply> myReplies = replyRepository.findByMemEmail(memEmail);
+
+            return ResponseEntity.ok(myReplies);
+        } catch (Exception e) {
+            e.printStackTrace();
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("유효하지 않은 토큰입니다.");
+        }
+    }
+
+    @GetMapping("/likes")
+    @Operation(summary = "내가 좋아요한 댓글 조회", description = "JWT에서 추출한 사용자 email을 기준으로 좋아요한 댓글 정보를 조회")
+    public ResponseEntity<?> getMyLikes(HttpServletRequest request) {
+        String token = jwtTokenUtil.extractTokenFromRequest(request);
+        if (token == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("토큰이 필요합니다.");
+        }
+
+        try {
+            String memEmail = jwtTokenUtil.extractUsername(token);
+            System.out.println("토큰에서 추출한 이메일: " + memEmail);
+
+            List<Reply> myLikes = replyRepository.findByMemEmail(memEmail);
+
+            return ResponseEntity.ok(myLikes);
+        } catch (Exception e) {
+            e.printStackTrace();
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("유효하지 않은 토큰입니다.");
+        }
+    }
+
     @GetMapping("/boards")
     public ResponseEntity<?> getMyBoards(HttpServletRequest request) {
-        // JWT 토큰 추출
         String token = jwtTokenUtil.extractTokenFromRequest(request);
 
         if (token == null) {
@@ -81,7 +124,6 @@ public class MyPageController {
         }
 
         try {
-            // 토큰에서 사용자 이메일 추출
             String memEmail = jwtTokenUtil.extractUsername(token);
             Optional<User> optionalUser = userRepository.findByMemEmail(memEmail);
 
@@ -92,7 +134,6 @@ public class MyPageController {
             User user = optionalUser.get();
             Long memId = user.getMem_id();
 
-            // 사용자 mem_id로 게시글 조회
             List<Board> boards = boardRepository.findBoardsByMemId(memId);
 
             // BoardDto 리스트로 변환
@@ -152,7 +193,6 @@ public class MyPageController {
             User user = optionalUser.get();
             Long memId = user.getMem_id();
 
-            // ✅ memId로 댓글 전체 조회
             List<Comment> comments = commentRepository.findCommentsByUserId(memId);
 
             // DTO로 변환
@@ -172,8 +212,6 @@ public class MyPageController {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("유효하지 않은 토큰입니다.");
         }
     }
-
-
 
 
     @PutMapping("/change-password")
@@ -198,6 +236,7 @@ public class MyPageController {
         }
     }
 
+
     @PutMapping("/change-memname")
     @Operation(summary = "이름 변경", description = "사용자가 입력한 이름으로 변경")
     public ResponseEntity<?> changeMemName(@RequestBody ChangeMemNameRequest request, HttpServletRequest httpRequest) {
@@ -219,6 +258,7 @@ public class MyPageController {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("이름 변경 중 오류 발생");
         }
     }
+
 
     @PutMapping("/change-memsex")
     @Operation(summary = "성별 변경", description = "사용자가 입력한 성별로 변경 (male, female, other만 허용)")

--- a/CineHive/src/main/java/com/example/CineHive/controller/myPage/MyPageController.java
+++ b/CineHive/src/main/java/com/example/CineHive/controller/myPage/MyPageController.java
@@ -6,9 +6,13 @@ import com.example.CineHive.entity.User;
 import com.example.CineHive.entity.board.*;
 
 import com.example.CineHive.entity.reply.Reply;
+import com.example.CineHive.entity.reply.ReplyDisLike;
+import com.example.CineHive.entity.reply.ReplyLike;
 import com.example.CineHive.entity.videotype.Movie;
 import com.example.CineHive.repository.UserRepository;
 import com.example.CineHive.repository.board.*;
+import com.example.CineHive.repository.reply.ReplyDisLikeRepository;
+import com.example.CineHive.repository.reply.ReplyLikeRepository;
 import com.example.CineHive.repository.reply.ReplyRepository;
 import com.example.CineHive.repository.videos.movie.MovieRepository;
 import com.example.CineHive.service.reply.ReplyBookmarkService;
@@ -43,6 +47,9 @@ public class MyPageController {
     private final LikeRepository likeRepository;
     private final DisLikeRepository dislikeRepository;
     private final BookmarkRepository bookmarkRepository;
+    private final ReplyLikeRepository replyLikeRepository;
+    private final ReplyDisLikeRepository replyDisLikeRepository;
+
 
     @GetMapping("/info")
     @Operation(summary = "내 정보 조회", description = "JWT를 통해 인증된 사용자의 기본 정보를 조회합니다.")
@@ -342,4 +349,54 @@ public class MyPageController {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("유효하지 않은 토큰입니다.");
         }
     }
+
+    @GetMapping("/reply-likes")
+    @Operation(summary = "내가 좋아요 누른 감상평 조회", description = "JWT를 통해 인증된 사용자가 좋아요한 감상평 목록을 조회합니다.")
+    public ResponseEntity<?> getLikedReplies(HttpServletRequest request) {
+        String token = jwtTokenUtil.extractTokenFromRequest(request);
+        if (token == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("토큰이 필요합니다.");
+        }
+
+        try {
+            String memEmail = jwtTokenUtil.extractUsername(token);
+
+            List<ReplyLike> replyLikes = replyLikeRepository.findByMemEmail(memEmail);
+            List<Long> replyIds = replyLikes.stream()
+                    .map(ReplyLike::getReplyId)
+                    .collect(Collectors.toList());
+
+            List<Reply> likedReplies = replyRepository.findAllById(replyIds);
+
+            return ResponseEntity.ok(likedReplies);
+        } catch (Exception e) {
+            e.printStackTrace();
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("좋아요 감상평 조회 실패");
+        }
+    }
+
+
+
+    @GetMapping("/reply-dislikes")
+    public ResponseEntity<?> getDislikedReplies(HttpServletRequest request) {
+        String token = jwtTokenUtil.extractTokenFromRequest(request);
+        if (token == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("토큰이 필요합니다.");
+        }
+
+        try {
+            String memEmail = jwtTokenUtil.extractUsername(token);
+            List<ReplyDisLike> replyDislikes = replyDisLikeRepository.findByMemEmail(memEmail);
+            List<Long> replyIds = replyDislikes.stream()
+                    .map(ReplyDisLike::getReplyId)
+                    .collect(Collectors.toList());
+            List<Reply> replies = replyRepository.findAllById(replyIds);
+            return ResponseEntity.ok(replies);
+        } catch (Exception e) {
+            e.printStackTrace();
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("싫어요 감상평 조회 실패");
+        }
+    }
+
+
 }

--- a/CineHive/src/main/java/com/example/CineHive/controller/myPage/MyPageController.java
+++ b/CineHive/src/main/java/com/example/CineHive/controller/myPage/MyPageController.java
@@ -1,6 +1,7 @@
 package com.example.CineHive.controller.myPage;
 
 import com.example.CineHive.dto.board.GetListBoardDto;
+import com.example.CineHive.dto.user.ChangeMemNameRequest;
 import com.example.CineHive.dto.user.ChangePasswordRequest;
 import com.example.CineHive.entity.board.Board;
 import com.example.CineHive.entity.videotype.Movie;
@@ -59,24 +60,24 @@ public class MyPageController {
         }
     }
 
-    @GetMapping("/boards")
-    @Operation(summary = "사용자가 작성한 게시글 목록 조회", description = "JWT에서 추출한 사용자 email을 기준으로 본인이 작성한 게시글 목록을 조회합니다.")
-    public ResponseEntity<?> getUserBoards(HttpServletRequest request) {
-        String token = jwtTokenUtil.extractTokenFromRequest(request);
-        if (token == null) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("토큰이 필요합니다.");
-        }
-
-        try {
-            String memEmail = jwtTokenUtil.extractUsername(token);
-            List<Board> boards = boardService.getBoardsByMemEmail(memEmail);
-
-            return ResponseEntity.ok(boards);
-        } catch (Exception e) {
-            e.printStackTrace();
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("유효하지 않은 토큰입니다.");
-        }
-    }
+//    @GetMapping("/boards")
+//    @Operation(summary = "사용자가 작성한 게시글 목록 조회", description = "JWT에서 추출한 사용자 email을 기준으로 본인이 작성한 게시글 목록을 조회합니다.")
+//    public ResponseEntity<?> getUserBoards(HttpServletRequest request) {
+//        String token = jwtTokenUtil.extractTokenFromRequest(request);
+//        if (token == null) {
+//            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("토큰이 필요합니다.");
+//        }
+//
+//        try {
+//            String memEmail = jwtTokenUtil.extractUsername(token);
+//            List<Board> boards = boardService.getBoardsByMemEmail(memEmail);
+//
+//            return ResponseEntity.ok(boards);
+//        } catch (Exception e) {
+//            e.printStackTrace();
+//            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("유효하지 않은 토큰입니다.");
+//        }
+//    }
 
     @PutMapping("/change-password")
     @Operation(summary = "비밀번호 변경", description = "기존 비밀번호 확인 후 새 비밀번호로 변경")
@@ -99,5 +100,29 @@ public class MyPageController {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("비밀번호 변경 중 오류 발생");
         }
     }
+
+    @PutMapping("/change-memname")
+    @Operation(summary = "이름 변경", description = "사용자가 입력한 이름으로 변경")
+    public ResponseEntity<?> changeMemName(@RequestBody ChangeMemNameRequest request, HttpServletRequest httpRequest) {
+        String token = jwtTokenUtil.extractTokenFromRequest(httpRequest);
+        if (token == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("토큰이 필요합니다.");
+        }
+
+        try {
+            String email = jwtTokenUtil.extractUsername(token);
+            boolean result = userService.changeMemName(email, request.getNewMemName());
+            if (result) {
+                return ResponseEntity.ok("이름이 성공적으로 변경되었습니다.");
+            } else {
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("이름 변경 실패");
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("이름 변경 중 오류 발생");
+        }
+    }
+
+
 
 }

--- a/CineHive/src/main/java/com/example/CineHive/controller/myPage/MyPageController.java
+++ b/CineHive/src/main/java/com/example/CineHive/controller/myPage/MyPageController.java
@@ -7,20 +7,14 @@ import com.example.CineHive.dto.user.ChangeMemNameRequest;
 import com.example.CineHive.dto.user.ChangeMemSexRequest;
 import com.example.CineHive.dto.user.ChangePasswordRequest;
 import com.example.CineHive.entity.User;
-import com.example.CineHive.entity.board.Board;
-import com.example.CineHive.entity.board.BoardDisLike;
-import com.example.CineHive.entity.board.BoardLike;
-import com.example.CineHive.entity.board.Comment;
+import com.example.CineHive.entity.board.*;
 
 import com.example.CineHive.entity.reply.Reply;
 import com.example.CineHive.entity.videotype.Movie;
 import com.example.CineHive.mapper.CommentMapper;
 import com.example.CineHive.repository.LoginHistoryRepository;
 import com.example.CineHive.repository.UserRepository;
-import com.example.CineHive.repository.board.BoardRepository;
-import com.example.CineHive.repository.board.CommentRepository;
-import com.example.CineHive.repository.board.DisLikeRepository;
-import com.example.CineHive.repository.board.LikeRepository;
+import com.example.CineHive.repository.board.*;
 import com.example.CineHive.repository.reply.ReplyRepository;
 import com.example.CineHive.repository.videos.movie.MovieRepository;
 import com.example.CineHive.service.UserService;
@@ -58,6 +52,7 @@ public class MyPageController {
     private final CommentRepository commentRepository;
     private final LikeRepository likeRepository;
     private final DisLikeRepository dislikeRepository;
+    private final BookmarkRepository bookmarkRepository;
 
     @GetMapping("/info")
     @Operation(summary = "내 정보 조회", description = "JWT를 통해 인증된 사용자의 기본 정보를 조회합니다.")
@@ -215,6 +210,44 @@ public class MyPageController {
         } catch (Exception e) {
             e.printStackTrace();
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("유효하지 않은 토큰입니다.");
+        }
+    }
+
+    @GetMapping("/boardbookmarks")
+    @Operation(summary = "내가 즐겨찾기한 게시글 조회", description = "JWT에서 추출한 사용자 email을 기준으로 즐겨찾기한 게시글 정보를 조회")
+    public ResponseEntity<?> getMyBookmarkedBoards(HttpServletRequest request) {
+        String token = jwtTokenUtil.extractTokenFromRequest(request);
+        if (token == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("토큰이 필요합니다.");
+        }
+
+        try {
+            String memEmail = jwtTokenUtil.extractUsername(token);
+            Optional<User> optionalUser = userRepository.findByMemEmail(memEmail);
+
+            if (optionalUser.isEmpty()) {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND).body("사용자를 찾을 수 없습니다.");
+            }
+
+            User user = optionalUser.get();
+            List<Bookmark> bookmarks = bookmarkRepository.findByUser(user);
+
+            List<Map<String, Object>> bookmarkedBoards = bookmarks.stream()
+                    .map(bookmark -> {
+                        Map<String, Object> map = new HashMap<>();
+                        map.put("boardId", bookmark.getBoard().getId());
+                        map.put("boardTitle", bookmark.getBoard().getBrdTitle());
+                        map.put("boardContent", bookmark.getBoard().getBrdContent());
+                        map.put("boardViews", bookmark.getBoard().getViews());
+                        map.put("boardRegDate", bookmark.getBoard().getBrdRegDate());
+                        return map;
+                    })
+                    .collect(Collectors.toList());
+
+            return ResponseEntity.ok(bookmarkedBoards);
+        } catch (Exception e) {
+            e.printStackTrace();
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("서버 오류 발생");
         }
     }
 

--- a/CineHive/src/main/java/com/example/CineHive/controller/myPage/MyPageController.java
+++ b/CineHive/src/main/java/com/example/CineHive/controller/myPage/MyPageController.java
@@ -1,31 +1,22 @@
 package com.example.CineHive.controller.myPage;
 
 import com.example.CineHive.dto.board.BoardDto;
-import com.example.CineHive.dto.board.GetListBoardDto;
 import com.example.CineHive.dto.comment.CommentDto;
-import com.example.CineHive.dto.user.ChangeMemNameRequest;
-import com.example.CineHive.dto.user.ChangeMemSexRequest;
-import com.example.CineHive.dto.user.ChangePasswordRequest;
 import com.example.CineHive.entity.User;
 import com.example.CineHive.entity.board.*;
 
 import com.example.CineHive.entity.reply.Reply;
 import com.example.CineHive.entity.videotype.Movie;
-import com.example.CineHive.mapper.CommentMapper;
-import com.example.CineHive.repository.LoginHistoryRepository;
 import com.example.CineHive.repository.UserRepository;
 import com.example.CineHive.repository.board.*;
 import com.example.CineHive.repository.reply.ReplyRepository;
 import com.example.CineHive.repository.videos.movie.MovieRepository;
-import com.example.CineHive.service.UserService;
-import com.example.CineHive.service.board.BoardService;
 import com.example.CineHive.service.reply.ReplyBookmarkService;
 import com.example.CineHive.util.JwtTokenUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -47,7 +38,6 @@ public class MyPageController {
     private final MovieRepository movieRepository;
     private final BoardRepository boardRepository;
     private final ReplyRepository replyRepository;
-    private final UserService userService;
     private final UserRepository userRepository;
     private final CommentRepository commentRepository;
     private final LikeRepository likeRepository;
@@ -350,77 +340,6 @@ public class MyPageController {
         } catch (Exception e) {
             e.printStackTrace();
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("유효하지 않은 토큰입니다.");
-        }
-    }
-
-
-
-
-    @PutMapping("/change-password")
-    @Operation(summary = "비밀번호 변경", description = "기존 비밀번호 확인 후 새 비밀번호로 변경")
-    public ResponseEntity<?> changePassword(@RequestBody ChangePasswordRequest request, HttpServletRequest httpRequest) {
-        String token = jwtTokenUtil.extractTokenFromRequest(httpRequest);
-        if (token == null) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("토큰이 필요합니다.");
-        }
-
-        try {
-            String email = jwtTokenUtil.extractUsername(token);
-            boolean result = userService.changePassword(email, request.getOldPassword(), request.getNewPassword());
-            if (result) {
-                return ResponseEntity.ok("비밀번호가 성공적으로 변경되었습니다.");
-            } else {
-                return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("기존 비밀번호가 일치하지 않습니다.");
-            }
-        } catch (Exception e) {
-            e.printStackTrace();
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("비밀번호 변경 중 오류 발생");
-        }
-    }
-
-
-    @PutMapping("/change-memname")
-    @Operation(summary = "이름 변경", description = "사용자가 입력한 이름으로 변경")
-    public ResponseEntity<?> changeMemName(@RequestBody ChangeMemNameRequest request, HttpServletRequest httpRequest) {
-        String token = jwtTokenUtil.extractTokenFromRequest(httpRequest);
-        if (token == null) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("토큰이 필요합니다.");
-        }
-
-        try {
-            String email = jwtTokenUtil.extractUsername(token);
-            boolean result = userService.changeMemName(email, request.getNewMemName());
-            if (result) {
-                return ResponseEntity.ok("이름이 성공적으로 변경되었습니다.");
-            } else {
-                return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("이름 변경 실패");
-            }
-        } catch (Exception e) {
-            e.printStackTrace();
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("이름 변경 중 오류 발생");
-        }
-    }
-
-
-    @PutMapping("/change-memsex")
-    @Operation(summary = "성별 변경", description = "사용자가 입력한 성별로 변경 (male, female, other만 허용)")
-    public ResponseEntity<?> changeMemSex(@RequestBody ChangeMemSexRequest request, HttpServletRequest httpRequest) {
-        String token = jwtTokenUtil.extractTokenFromRequest(httpRequest);
-        if (token == null) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("토큰이 필요합니다.");
-        }
-
-        try {
-            String email = jwtTokenUtil.extractUsername(token);
-            boolean result = userService.changeMemSex(email, request.getNewMemSex());
-            if (result) {
-                return ResponseEntity.ok("성별이 성공적으로 변경되었습니다.");
-            } else {
-                return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("유효한 성별 값은 male, female, other 입니다.");
-            }
-        } catch (Exception e) {
-            e.printStackTrace();
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("성별 변경 중 오류 발생");
         }
     }
 }

--- a/CineHive/src/main/java/com/example/CineHive/controller/myPage/MyPageController.java
+++ b/CineHive/src/main/java/com/example/CineHive/controller/myPage/MyPageController.java
@@ -1,5 +1,6 @@
 package com.example.CineHive.controller.myPage;
 
+import com.example.CineHive.dto.board.BoardDto;
 import com.example.CineHive.dto.board.GetListBoardDto;
 import com.example.CineHive.dto.comment.CommentDto;
 import com.example.CineHive.dto.user.ChangeMemNameRequest;
@@ -70,6 +71,65 @@ public class MyPageController {
         }
     }
 
+    @GetMapping("/boards")
+    public ResponseEntity<?> getMyBoards(HttpServletRequest request) {
+        // JWT 토큰 추출
+        String token = jwtTokenUtil.extractTokenFromRequest(request);
+
+        if (token == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("토큰이 필요합니다.");
+        }
+
+        try {
+            // 토큰에서 사용자 이메일 추출
+            String memEmail = jwtTokenUtil.extractUsername(token);
+            Optional<User> optionalUser = userRepository.findByMemEmail(memEmail);
+
+            if (optionalUser.isEmpty()) {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND).body("사용자를 찾을 수 없습니다.");
+            }
+
+            User user = optionalUser.get();
+            Long memId = user.getMem_id();
+
+            // 사용자 mem_id로 게시글 조회
+            List<Board> boards = boardRepository.findBoardsByMemId(memId);
+
+            // BoardDto 리스트로 변환
+            List<BoardDto> boardDtos = boards.stream().map(board -> {
+                List<CommentDto> commentDtos = board.getComments().stream()
+                        .map(comment -> new CommentDto(
+                                comment.getId(),
+                                comment.getContent(),
+                                comment.getUser().getMemNickname(),
+                                comment.getUser().getMemEmail(),
+                                comment.getCreatedAt()
+                        ))
+                        .collect(Collectors.toList());
+
+                return new BoardDto(
+                        board.getId(),
+                        board.getBrdTitle(),
+                        board.getBrdContent(),
+                        board.getUser().getMemNickname(),
+                        board.getUser().getMemEmail(),
+                        board.getBrdRegDate(),
+                        board.getBookmarkCount(),
+                        board.getLikeCount(),
+                        board.getDisLikeCount(),
+                        board.getReportCount(),
+                        board.getCommentCount(),
+                        commentDtos,
+                        board.getViews()
+                );
+            }).collect(Collectors.toList());
+
+            return ResponseEntity.ok(boardDtos);
+        } catch (Exception e) {
+            e.printStackTrace();
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("유효하지 않은 토큰입니다.");
+        }
+    }
 
 
     @GetMapping("/comments")

--- a/CineHive/src/main/java/com/example/CineHive/controller/myPage/MyPageController.java
+++ b/CineHive/src/main/java/com/example/CineHive/controller/myPage/MyPageController.java
@@ -1,0 +1,103 @@
+package com.example.CineHive.controller.myPage;
+
+import com.example.CineHive.dto.board.GetListBoardDto;
+import com.example.CineHive.dto.user.ChangePasswordRequest;
+import com.example.CineHive.entity.board.Board;
+import com.example.CineHive.entity.videotype.Movie;
+import com.example.CineHive.repository.LoginHistoryRepository;
+import com.example.CineHive.repository.board.BoardRepository;
+import com.example.CineHive.repository.videos.movie.MovieRepository;
+import com.example.CineHive.service.UserService;
+import com.example.CineHive.service.board.BoardService;
+import com.example.CineHive.service.reply.ReplyBookmarkService;
+import com.example.CineHive.util.JwtTokenUtil;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+
+
+@RestController
+@RequestMapping("/myPage")
+@RequiredArgsConstructor
+@Tag(name = "MyPage Controller", description = "마이페이지 관련 기능을 제공하는 API")
+public class MyPageController {
+    private final JwtTokenUtil jwtTokenUtil;
+    private final ReplyBookmarkService replyBookmarkService;
+    private final MovieRepository movieRepository;
+    private final BoardRepository boardRepository;
+    private final BoardService boardService;
+    private final UserService userService;
+
+    @GetMapping("/bookmarks")
+    @Operation(summary = "찜한 영화 목록 조회", description = "JWT에서 추출한 사용자 email을 기준으로 찜한 영화 정보를 조회")
+    public ResponseEntity<?> getFavoriteMovies(HttpServletRequest request) {
+        String token = jwtTokenUtil.extractTokenFromRequest(request);
+        System.out.println("받은 토큰: " + token);  // 추가
+        if (token == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("토큰이 필요합니다.");
+        }
+
+        try {
+            String memEmail = jwtTokenUtil.extractUsername(token);
+            System.out.println("토큰에서 추출한 이메일: " + memEmail);
+            // Step 1: 찜한 movieId 리스트 가져오기
+            List<Long> movieIds = replyBookmarkService.getBookmarkedMovieIdsByEmail(memEmail);
+
+            // Step 2: movieId들로 Movie 객체 조회
+            List<Movie> favoriteMovies = movieRepository.findAllById(movieIds);
+            return ResponseEntity.ok(favoriteMovies);
+        } catch (Exception e) {
+            e.printStackTrace();
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("유효하지 않은 토큰입니다.");
+        }
+    }
+
+    @GetMapping("/boards")
+    @Operation(summary = "사용자가 작성한 게시글 목록 조회", description = "JWT에서 추출한 사용자 email을 기준으로 본인이 작성한 게시글 목록을 조회합니다.")
+    public ResponseEntity<?> getUserBoards(HttpServletRequest request) {
+        String token = jwtTokenUtil.extractTokenFromRequest(request);
+        if (token == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("토큰이 필요합니다.");
+        }
+
+        try {
+            String memEmail = jwtTokenUtil.extractUsername(token);
+            List<Board> boards = boardService.getBoardsByMemEmail(memEmail);
+
+            return ResponseEntity.ok(boards);
+        } catch (Exception e) {
+            e.printStackTrace();
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("유효하지 않은 토큰입니다.");
+        }
+    }
+
+    @PutMapping("/change-password")
+    @Operation(summary = "비밀번호 변경", description = "기존 비밀번호 확인 후 새 비밀번호로 변경")
+    public ResponseEntity<?> changePassword(@RequestBody ChangePasswordRequest request, HttpServletRequest httpRequest) {
+        String token = jwtTokenUtil.extractTokenFromRequest(httpRequest);
+        if (token == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("토큰이 필요합니다.");
+        }
+
+        try {
+            String email = jwtTokenUtil.extractUsername(token);
+            boolean result = userService.changePassword(email, request.getOldPassword(), request.getNewPassword());
+            if (result) {
+                return ResponseEntity.ok("비밀번호가 성공적으로 변경되었습니다.");
+            } else {
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("기존 비밀번호가 일치하지 않습니다.");
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("비밀번호 변경 중 오류 발생");
+        }
+    }
+
+}

--- a/CineHive/src/main/java/com/example/CineHive/controller/oauth/app/RequestGoogleAppController.java
+++ b/CineHive/src/main/java/com/example/CineHive/controller/oauth/app/RequestGoogleAppController.java
@@ -8,7 +8,6 @@ import com.example.CineHive.service.oauth.GoogleUserService;
 import com.example.CineHive.util.JwtUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;

--- a/CineHive/src/main/java/com/example/CineHive/controller/oauth/app/RequestKakaoAppController.java
+++ b/CineHive/src/main/java/com/example/CineHive/controller/oauth/app/RequestKakaoAppController.java
@@ -5,7 +5,6 @@ import com.example.CineHive.dto.user.UserDto;
 import com.example.CineHive.entity.User;
 import com.example.CineHive.repository.UserRepository;
 import com.example.CineHive.service.oauth.KakaoUserService;
-import com.example.CineHive.service.UserService;
 import com.example.CineHive.util.JwtUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;

--- a/CineHive/src/main/java/com/example/CineHive/controller/oauth/web/RequestGoogleWebController.java
+++ b/CineHive/src/main/java/com/example/CineHive/controller/oauth/web/RequestGoogleWebController.java
@@ -1,7 +1,6 @@
 package com.example.CineHive.controller.oauth.web;
 
 import com.example.CineHive.dto.oauth.GoogleUserInfo;
-import com.example.CineHive.dto.oauth.KakaoUserInfo;
 import com.example.CineHive.entity.User;
 import com.example.CineHive.repository.UserRepository;
 import com.example.CineHive.service.oauth.GoogleUserService;

--- a/CineHive/src/main/java/com/example/CineHive/controller/oauth/web/RequestNaverWebController.java
+++ b/CineHive/src/main/java/com/example/CineHive/controller/oauth/web/RequestNaverWebController.java
@@ -1,7 +1,6 @@
 package com.example.CineHive.controller.oauth.web;
 
 import com.example.CineHive.dto.oauth.NaverUserInfo;
-import com.example.CineHive.dto.user.UserDto;
 import com.example.CineHive.entity.User;
 import com.example.CineHive.repository.UserRepository;
 import com.example.CineHive.service.oauth.NaverUserService;

--- a/CineHive/src/main/java/com/example/CineHive/dto/board/BoardDto.java
+++ b/CineHive/src/main/java/com/example/CineHive/dto/board/BoardDto.java
@@ -2,14 +2,11 @@ package com.example.CineHive.dto.board;
 
 
 import com.example.CineHive.dto.comment.CommentDto;
-import com.example.CineHive.entity.board.Board;
-import com.fasterxml.jackson.annotation.JsonBackReference;
-import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.springframework.security.core.userdetails.User;
 
 import java.time.LocalDateTime;
 import java.util.List;

--- a/CineHive/src/main/java/com/example/CineHive/dto/board/BoardDto.java
+++ b/CineHive/src/main/java/com/example/CineHive/dto/board/BoardDto.java
@@ -21,7 +21,7 @@ public class BoardDto {
     private String brdContent;
     private String memNickname;
     private String memEmail;
-    private LocalDateTime brgRedDate;
+    private LocalDateTime brdRegDate;
     private int bookmarkCount;
     private int likeCount;
     private int dislikeCount;

--- a/CineHive/src/main/java/com/example/CineHive/dto/board/BoardSearchDto.java
+++ b/CineHive/src/main/java/com/example/CineHive/dto/board/BoardSearchDto.java
@@ -4,7 +4,6 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.springframework.cglib.core.Local;
 
 import java.time.LocalDateTime;
 

--- a/CineHive/src/main/java/com/example/CineHive/dto/comment/CommentDto.java
+++ b/CineHive/src/main/java/com/example/CineHive/dto/comment/CommentDto.java
@@ -17,4 +17,5 @@ public class CommentDto {
     private String memNickname;
     private String memEmail;
     private LocalDateTime brgRedDate;
+    private Long boardId;
 }

--- a/CineHive/src/main/java/com/example/CineHive/dto/comment/CommentDto.java
+++ b/CineHive/src/main/java/com/example/CineHive/dto/comment/CommentDto.java
@@ -4,7 +4,6 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.springframework.cglib.core.Local;
 
 import java.time.LocalDateTime;
 

--- a/CineHive/src/main/java/com/example/CineHive/dto/user/ChangeMemNameRequest.java
+++ b/CineHive/src/main/java/com/example/CineHive/dto/user/ChangeMemNameRequest.java
@@ -1,0 +1,10 @@
+package com.example.CineHive.dto.user;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ChangeMemNameRequest {
+    private String newMemName;
+}

--- a/CineHive/src/main/java/com/example/CineHive/dto/user/ChangeMemSexRequest.java
+++ b/CineHive/src/main/java/com/example/CineHive/dto/user/ChangeMemSexRequest.java
@@ -1,0 +1,10 @@
+package com.example.CineHive.dto.user;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ChangeMemSexRequest {
+    private String newMemSex;
+}

--- a/CineHive/src/main/java/com/example/CineHive/dto/user/ChangePasswordRequest.java
+++ b/CineHive/src/main/java/com/example/CineHive/dto/user/ChangePasswordRequest.java
@@ -1,0 +1,14 @@
+package com.example.CineHive.dto.user;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ChangePasswordRequest {
+    private String oldPassword;
+    private String newPassword;
+}

--- a/CineHive/src/main/java/com/example/CineHive/entity/User.java
+++ b/CineHive/src/main/java/com/example/CineHive/entity/User.java
@@ -57,6 +57,4 @@ public class User {
         this.memRegisterDatetime = LocalDateTime.now();
     }
 
-
-
 }

--- a/CineHive/src/main/java/com/example/CineHive/mapper/BoardMapper.java
+++ b/CineHive/src/main/java/com/example/CineHive/mapper/BoardMapper.java
@@ -17,7 +17,7 @@ public class BoardMapper {
         dto.setBrdContent(board.getBrdContent());
         dto.setMemNickname(board.getUser().getMemNickname());
         dto.setMemEmail(board.getUser().getMemEmail());
-        dto.setBrgRedDate(board.getBrdRegDate());
+        dto.setBrdRegDate(board.getBrdRegDate());
         dto.setBookmarkCount(board.getBookmarkCount());
         dto.setLikeCount(board.getLikeCount());
         dto.setDislikeCount(board.getDisLikeCount());

--- a/CineHive/src/main/java/com/example/CineHive/mapper/CommentMapper.java
+++ b/CineHive/src/main/java/com/example/CineHive/mapper/CommentMapper.java
@@ -17,7 +17,8 @@ public class CommentMapper {
                 comment.getContent(),
                 comment.getUser().getMemNickname(),
                 comment.getUser().getMemEmail(),
-                comment.getUser().getMemRegisterDatetime()
+                comment.getUser().getMemRegisterDatetime(),
+                comment.getBoard().getId()
         );
     }
 

--- a/CineHive/src/main/java/com/example/CineHive/repository/UserRepository.java
+++ b/CineHive/src/main/java/com/example/CineHive/repository/UserRepository.java
@@ -13,4 +13,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByMemEmail(String memEmail);
 
     Optional<User> findByMemNickname(String memNickname);
+
+
 }

--- a/CineHive/src/main/java/com/example/CineHive/repository/UserRepository.java
+++ b/CineHive/src/main/java/com/example/CineHive/repository/UserRepository.java
@@ -14,5 +14,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByMemNickname(String memNickname);
 
+    void deleteByMemEmail(String memEmail);
 
 }

--- a/CineHive/src/main/java/com/example/CineHive/repository/board/BoardRepository.java
+++ b/CineHive/src/main/java/com/example/CineHive/repository/board/BoardRepository.java
@@ -20,4 +20,5 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
     @Query(value = "SELECT * FROM board WHERE mem_id = :memId", nativeQuery = true)
     List<Board> findBoardsByMemId(@Param("memId") Long memId);
 
+    void deleteByUserMemEmail(String memEmail);
 }

--- a/CineHive/src/main/java/com/example/CineHive/repository/board/BoardRepository.java
+++ b/CineHive/src/main/java/com/example/CineHive/repository/board/BoardRepository.java
@@ -15,4 +15,5 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
             "OR LOWER(b.brdContent) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
             "OR LOWER(u.memNickname) LIKE LOWER(CONCAT('%', :keyword, '%')))")
     List<Board> searchByKeyword(@Param("keyword") String keyword);
+    List<Board> findByMemEmail(String memEmail);
 }

--- a/CineHive/src/main/java/com/example/CineHive/repository/board/BoardRepository.java
+++ b/CineHive/src/main/java/com/example/CineHive/repository/board/BoardRepository.java
@@ -16,4 +16,8 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
             "OR LOWER(u.memNickname) LIKE LOWER(CONCAT('%', :keyword, '%')))")
     List<Board> searchByKeyword(@Param("keyword") String keyword);
     List<Board> findByMemEmail(String memEmail);
+
+    @Query(value = "SELECT * FROM board WHERE mem_id = :memId", nativeQuery = true)
+    List<Board> findBoardsByMemId(@Param("memId") Long memId);
+
 }

--- a/CineHive/src/main/java/com/example/CineHive/repository/board/BookmarkRepository.java
+++ b/CineHive/src/main/java/com/example/CineHive/repository/board/BookmarkRepository.java
@@ -16,4 +16,6 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
     int countByBoard(Board board);
 
     List<Bookmark> findByUser(User user);
+
+    void deleteByUser_MemEmail(String memEmail);
 }

--- a/CineHive/src/main/java/com/example/CineHive/repository/board/BookmarkRepository.java
+++ b/CineHive/src/main/java/com/example/CineHive/repository/board/BookmarkRepository.java
@@ -6,6 +6,7 @@ import com.example.CineHive.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -13,4 +14,6 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
     Optional<Bookmark> findByUserAndBoard(User user, Board board);
     void deleteByUserAndBoard(User user, Board board);
     int countByBoard(Board board);
+
+    List<Bookmark> findByUser(User user);
 }

--- a/CineHive/src/main/java/com/example/CineHive/repository/board/CommentRepository.java
+++ b/CineHive/src/main/java/com/example/CineHive/repository/board/CommentRepository.java
@@ -16,4 +16,7 @@ public interface CommentRepository extends JpaRepository <Comment,Long> {
 
     @Query(value = "SELECT * FROM comment WHERE user_id = :memId", nativeQuery = true)
     List<Comment> findCommentsByUserId(@Param("memId") Long memId);
+
+    void deleteByUser_MemEmail(String memEmail);
+
 }

--- a/CineHive/src/main/java/com/example/CineHive/repository/board/CommentRepository.java
+++ b/CineHive/src/main/java/com/example/CineHive/repository/board/CommentRepository.java
@@ -3,8 +3,9 @@ package com.example.CineHive.repository.board;
 import com.example.CineHive.entity.User;
 import com.example.CineHive.entity.board.Board;
 import com.example.CineHive.entity.board.Comment;
-import org.springframework.boot.autoconfigure.security.SecurityProperties;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -12,4 +13,7 @@ public interface CommentRepository extends JpaRepository <Comment,Long> {
     List<Comment> findByUserAndBoard(User user, Board board);
 
     List<Comment> findByBoard(Board board);
+
+    @Query(value = "SELECT * FROM comment WHERE user_id = :memId", nativeQuery = true)
+    List<Comment> findCommentsByUserId(@Param("memId") Long memId);
 }

--- a/CineHive/src/main/java/com/example/CineHive/repository/board/DisLikeRepository.java
+++ b/CineHive/src/main/java/com/example/CineHive/repository/board/DisLikeRepository.java
@@ -3,12 +3,16 @@ package com.example.CineHive.repository.board;
 import com.example.CineHive.entity.User;
 import com.example.CineHive.entity.board.Board;
 import com.example.CineHive.entity.board.BoardDisLike;
+import com.example.CineHive.entity.board.BoardLike;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface DisLikeRepository extends JpaRepository<BoardDisLike, Long> {
     Optional<BoardDisLike> findByUserAndBoard(User user, Board board);
 
     long countByBoard(Board board);
+
+    List<BoardDisLike> findByUser(User user);
 }

--- a/CineHive/src/main/java/com/example/CineHive/repository/board/DisLikeRepository.java
+++ b/CineHive/src/main/java/com/example/CineHive/repository/board/DisLikeRepository.java
@@ -15,4 +15,6 @@ public interface DisLikeRepository extends JpaRepository<BoardDisLike, Long> {
     long countByBoard(Board board);
 
     List<BoardDisLike> findByUser(User user);
+
+    void deleteByUser_MemEmail(String memEmail);
 }

--- a/CineHive/src/main/java/com/example/CineHive/repository/board/LikeRepository.java
+++ b/CineHive/src/main/java/com/example/CineHive/repository/board/LikeRepository.java
@@ -12,4 +12,6 @@ public interface LikeRepository extends JpaRepository<BoardLike, Long> {
     Optional<BoardLike> findByUserAndBoard(User user, Board board);
     long countByBoard(Board board);
     List<BoardLike> findByUser(User user);
+
+    void deleteByUser_MemEmail(String memEmail);
 }

--- a/CineHive/src/main/java/com/example/CineHive/repository/board/LikeRepository.java
+++ b/CineHive/src/main/java/com/example/CineHive/repository/board/LikeRepository.java
@@ -5,10 +5,11 @@ import com.example.CineHive.entity.board.Board;
 import com.example.CineHive.entity.board.BoardLike;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface LikeRepository extends JpaRepository<BoardLike, Long> {
     Optional<BoardLike> findByUserAndBoard(User user, Board board);
-
     long countByBoard(Board board);
+    List<BoardLike> findByUser(User user);
 }

--- a/CineHive/src/main/java/com/example/CineHive/repository/reply/ReplyBookmarkRepository.java
+++ b/CineHive/src/main/java/com/example/CineHive/repository/reply/ReplyBookmarkRepository.java
@@ -20,5 +20,5 @@ public interface ReplyBookmarkRepository extends JpaRepository<ReplyBookmark, Lo
     List<Long> findMovieIdsByMemEmail(@Param("memEmail") String memEmail);
 
 
-
+    void deleteByMemEmail(String memEmail);
 }

--- a/CineHive/src/main/java/com/example/CineHive/repository/reply/ReplyBookmarkRepository.java
+++ b/CineHive/src/main/java/com/example/CineHive/repository/reply/ReplyBookmarkRepository.java
@@ -1,17 +1,24 @@
 package com.example.CineHive.repository.reply;
 
-import com.example.CineHive.entity.User;
-import com.example.CineHive.entity.board.Board;
-import com.example.CineHive.entity.board.Bookmark;
-import com.example.CineHive.entity.reply.ReplyBookmark;
-import org.springframework.data.jpa.repository.JpaRepository;
-
+import java.util.List;
 import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.example.CineHive.entity.reply.ReplyBookmark;
+import com.example.CineHive.entity.videotype.Movie;
 
 public interface ReplyBookmarkRepository extends JpaRepository<ReplyBookmark, Long> {
 
     Optional<ReplyBookmark> findByMemEmailAndMovieId(String memEmail, Long movieId);
 
     long countByMovieId(Long movieId);
+
+    @Query("SELECT r.movieId FROM ReplyBookmark r WHERE r.memEmail = :memEmail")
+    List<Long> findMovieIdsByMemEmail(@Param("memEmail") String memEmail);
+
+
 
 }

--- a/CineHive/src/main/java/com/example/CineHive/repository/reply/ReplyDisLikeRepository.java
+++ b/CineHive/src/main/java/com/example/CineHive/repository/reply/ReplyDisLikeRepository.java
@@ -1,9 +1,11 @@
 package com.example.CineHive.repository.reply;
 
+import com.example.CineHive.entity.User;
 import com.example.CineHive.entity.reply.ReplyDisLike;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -11,4 +13,7 @@ public interface ReplyDisLikeRepository extends JpaRepository<ReplyDisLike, Long
     boolean existsByMemEmailAndReplyId(String memEmail, Long replyId);
     void deleteByMemEmailAndReplyId(String memEmail, Long replyId);
     long countByReplyId(Long replyId);
+
+    List<ReplyDisLike> findByMemEmail(String memEmail);
+
 }

--- a/CineHive/src/main/java/com/example/CineHive/repository/reply/ReplyDisLikeRepository.java
+++ b/CineHive/src/main/java/com/example/CineHive/repository/reply/ReplyDisLikeRepository.java
@@ -16,4 +16,5 @@ public interface ReplyDisLikeRepository extends JpaRepository<ReplyDisLike, Long
 
     List<ReplyDisLike> findByMemEmail(String memEmail);
 
+    void deleteByMemEmail(String memEmail);
 }

--- a/CineHive/src/main/java/com/example/CineHive/repository/reply/ReplyLikeRepository.java
+++ b/CineHive/src/main/java/com/example/CineHive/repository/reply/ReplyLikeRepository.java
@@ -16,4 +16,6 @@ public interface ReplyLikeRepository extends JpaRepository<ReplyLike, Long>{
 
     List<ReplyLike> findByMemEmail(String memEmail);
 
+    void deleteByMemEmail(String memEmail);
+
 }

--- a/CineHive/src/main/java/com/example/CineHive/repository/reply/ReplyLikeRepository.java
+++ b/CineHive/src/main/java/com/example/CineHive/repository/reply/ReplyLikeRepository.java
@@ -1,10 +1,11 @@
 package com.example.CineHive.repository.reply;
 
-import com.example.CineHive.entity.reply.ReplyDisLike;
+import com.example.CineHive.entity.User;
 import com.example.CineHive.entity.reply.ReplyLike;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -12,4 +13,7 @@ public interface ReplyLikeRepository extends JpaRepository<ReplyLike, Long>{
     boolean existsByMemEmailAndReplyId(String memEmail, Long replyId);
     void deleteByMemEmailAndReplyId(String memEmail, Long replyId);
     long countByReplyId(Long replyId);
+
+    List<ReplyLike> findByMemEmail(String memEmail);
+
 }

--- a/CineHive/src/main/java/com/example/CineHive/repository/reply/ReplyRepository.java
+++ b/CineHive/src/main/java/com/example/CineHive/repository/reply/ReplyRepository.java
@@ -12,6 +12,4 @@ public interface ReplyRepository extends JpaRepository<Reply, Long> {
     List<Reply> findByMovieId(Long movieId);
     List<Reply> findByMemEmail(String memEmail);
 
-    List<Reply> findByMemNickname(String memNickname);
-
 }

--- a/CineHive/src/main/java/com/example/CineHive/repository/reply/ReplyRepository.java
+++ b/CineHive/src/main/java/com/example/CineHive/repository/reply/ReplyRepository.java
@@ -11,5 +11,5 @@ public interface ReplyRepository extends JpaRepository<Reply, Long> {
 
     List<Reply> findByMovieId(Long movieId);
     List<Reply> findByMemEmail(String memEmail);
-
+    void deleteByMemEmail(String memEmail);
 }

--- a/CineHive/src/main/java/com/example/CineHive/service/UserService.java
+++ b/CineHive/src/main/java/com/example/CineHive/service/UserService.java
@@ -113,4 +113,19 @@ public class UserService{
         return userRepository.findByMemEmail(memEmail).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
     }
 
+    @Transactional
+    public boolean changePassword(String memEmail, String oldPassword, String newPassword) {
+        User user = userRepository.findByMemEmail(memEmail)
+                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
+
+        if (!passwordEncoder.matches(oldPassword, user.getMemPw())) {
+            return false;
+        }
+
+        user.setMemPw(passwordEncoder.encode(newPassword));
+        userRepository.save(user);
+        return true;
+    }
+
+
 }

--- a/CineHive/src/main/java/com/example/CineHive/service/UserService.java
+++ b/CineHive/src/main/java/com/example/CineHive/service/UserService.java
@@ -138,5 +138,21 @@ public class UserService{
         return true;
     }
 
+    @Transactional
+    public boolean changeMemSex(String memEmail, String newMemSex) {
+        if (!newMemSex.equalsIgnoreCase("male") &&
+                !newMemSex.equalsIgnoreCase("female") &&
+                !newMemSex.equalsIgnoreCase("other")) {
+            return false; // 유효하지 않은 값일 경우
+        }
+
+        User user = userRepository.findByMemEmail(memEmail)
+                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
+
+        user.setMemSex(newMemSex.toLowerCase()); // 저장 시 소문자로 통일
+        userRepository.save(user);
+        return true;
+    }
+
 
 }

--- a/CineHive/src/main/java/com/example/CineHive/service/UserService.java
+++ b/CineHive/src/main/java/com/example/CineHive/service/UserService.java
@@ -133,7 +133,11 @@ public class UserService{
         User user = userRepository.findByMemEmail(memEmail)
                 .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
 
-        user.setMemName(newMemName);
+        if (newMemName == null || newMemName.trim().isEmpty()) {
+            throw new RuntimeException("변경할 이름을 입력해야 합니다.");
+        }
+
+        user.setMemName(newMemName.trim()); // 공백 제거하고 저장
         userRepository.save(user);
         return true;
     }

--- a/CineHive/src/main/java/com/example/CineHive/service/UserService.java
+++ b/CineHive/src/main/java/com/example/CineHive/service/UserService.java
@@ -11,7 +11,7 @@ import com.example.CineHive.repository.UserRepository;
 import com.example.CineHive.util.JwtUtil;
 import io.micrometer.common.util.StringUtils;
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.transaction.Transactional;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -125,6 +125,14 @@ public class UserService{
         user.setMemPw(passwordEncoder.encode(newPassword));
         userRepository.save(user);
         return true;
+    }
+
+    @Transactional(readOnly = true)
+    public boolean checkPassword(String memEmail, String password) {
+        User user = userRepository.findByMemEmail(memEmail)
+                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
+
+        return passwordEncoder.matches(password, user.getMemPw());
     }
 
 

--- a/CineHive/src/main/java/com/example/CineHive/service/UserService.java
+++ b/CineHive/src/main/java/com/example/CineHive/service/UserService.java
@@ -128,4 +128,15 @@ public class UserService{
     }
 
 
+    @Transactional
+    public boolean changeMemName(String memEmail, String newMemName) {
+        User user = userRepository.findByMemEmail(memEmail)
+                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
+
+        user.setMemName(newMemName);
+        userRepository.save(user);
+        return true;
+    }
+
+
 }

--- a/CineHive/src/main/java/com/example/CineHive/service/board/BoardService.java
+++ b/CineHive/src/main/java/com/example/CineHive/service/board/BoardService.java
@@ -117,4 +117,8 @@ public class BoardService {
                 .map(BoardMapper::convertToSearchDto)
                 .collect(Collectors.toList());
     }
+
+    public List<Board> getBoardsByMemEmail(String email) {
+        return boardRepository.findByMemEmail(email);
+    }
 }

--- a/CineHive/src/main/java/com/example/CineHive/service/reply/ReplyBookmarkService.java
+++ b/CineHive/src/main/java/com/example/CineHive/service/reply/ReplyBookmarkService.java
@@ -1,12 +1,14 @@
 package com.example.CineHive.service.reply;
 
 import com.example.CineHive.entity.reply.ReplyBookmark;
+import com.example.CineHive.entity.videotype.Movie;
 import com.example.CineHive.repository.reply.ReplyBookmarkRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -35,4 +37,10 @@ public class ReplyBookmarkService {
     public long getBookmarkCount(Long movieId) {
         return replyBookmarkRepository.countByMovieId(movieId);
     }
+
+    public List<Long> getBookmarkedMovieIdsByEmail(String memEmail) {
+        return replyBookmarkRepository.findMovieIdsByMemEmail(memEmail);
+    }
+
+
 }


### PR DESCRIPTION
## 작업한 내용
<!-- 작업한 내용을 입력하세요 -->
1. 현재 로그인 중인 사용자가 찜한(`reply_bookmark`) 목록 출력
2. 현재 로그인 중인 사용자 비밀번호 변경
3. 현재 로그인 중인 사용자의 이름(`mem_nickname`) 변경
4. 현재 로그인 중인 사용자의 성별(`mem_sex`) 변경
5. 현재 로그인 중인 사용자가 작성한 댓글(`comment`) 조회
6. 현재 로그인 중인 사용자 작성한 게시글(`board`) 조회
7. 현재 로그인 중인 사용자가 작성한 감성평(`reply`) 조회
8. 현재 로그인 중인 사용자가 좋아요한 게시글(`board_like`) 조회
9. 현재 로그인 중인 사용자가 싫어요한 게시글(`board_dislike`) 조회
10. 현재 로그인 중인 사용자가 좋아요한 감상평(`reply_likes`) 조회
11. 현재 로그인 중인 사용자가 싫어요한 감상평(`reply_dislikes`) 조회
12. 현재 로그인 중인 사용자 회원 탈퇴
## PR Point
<!-- PR Point를 입력하세요 -->
- 사용자 기반 마이페이지 기능 구현 : 찜한 목록, 작성한 게시글/댓글/감상평, 좋아요/싫어요 기록, 사용자 정보 수정(이름/성별/비밀번호 변경) 기능 추가
- 회원 탈퇴 기능 구현 : 회원 탈퇴 시 관련 컨텐츠(게시글, 댓글, 감상평 등) 일괄 삭제 처리
- 현재 로그인된 사용자(`JWT 인증`) 기준으로 데이터 필터링
- 영화/애니/드라마 찜 상세 페이지 이동 이슈 존재 : 현재 `movie/detail`은 정상 동작하나,` animation/detail 및 drama/detail` 이동은 수정 필요
## 스크린샷
<!-- 스크린샷을 첨부하세요 -->